### PR TITLE
Restore redis-cluster build context to unblock CI (INF-139)

### DIFF
--- a/bitnami/redis-cluster/8.6/SCT-RESTORED.md
+++ b/bitnami/redis-cluster/8.6/SCT-RESTORED.md
@@ -1,0 +1,14 @@
+# ⚠️ SCT-restored build context
+
+This `8.6/` build context (Dockerfile + `prebuildfs` + `rootfs`) was **restored by SCT** from
+this fork's own git history. Upstream Bitnami deleted it in commit
+`abfbafcc7e4` ("redis 8.8 is the new latest branch", 2026-05-26) as part of its "latest-only"
+policy, which broke our self-build CI (`No Dockerfiles found for redis-cluster`).
+
+- Restored from: `abfbafcc7e4~1` (`cf1ba4ce234`, redis-cluster 8.6.3-debian-12-r3).
+- Build inputs verified reachable on restore date (2026-06-01): `docker.io/bitnami/minideb:bookworm`
+  and the `redis-8.6.3` / `wait-for-port` stacksmith tarballs all resolve.
+- **This is a stopgap.** redis-cluster is the forcing function to migrate off Bitnami images
+  (see INF ticket under epic INP-493). Treat this as temporary until that migration lands.
+- Future upstream syncs will not re-delete this path (upstream no longer modifies it), so no merge
+  guard is required; if upstream ever re-adds a redis-cluster build context, reconcile then.

--- a/bitnami/redis-cluster/8.6/debian-12/Dockerfile
+++ b/bitnami/redis-cluster/8.6/debian-12/Dockerfile
@@ -1,0 +1,60 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+FROM docker.io/bitnami/minideb:bookworm
+
+ARG DOWNLOADS_URL="downloads.bitnami.com/files/stacksmith"
+ARG TARGETARCH
+
+LABEL org.opencontainers.image.base.name="docker.io/bitnami/minideb:bookworm" \
+      org.opencontainers.image.created="2026-05-23T10:56:18Z" \
+      org.opencontainers.image.description="Application packaged by Broadcom, Inc." \
+      org.opencontainers.image.documentation="https://github.com/bitnami/containers/tree/main/bitnami/redis-cluster/README.md" \
+      org.opencontainers.image.source="https://github.com/bitnami/containers/tree/main/bitnami/redis-cluster" \
+      org.opencontainers.image.title="redis-cluster" \
+      org.opencontainers.image.vendor="Broadcom, Inc." \
+      org.opencontainers.image.version="8.6.3"
+
+ENV HOME="/" \
+    OS_ARCH="${TARGETARCH:-amd64}" \
+    OS_FLAVOUR="debian-12" \
+    OS_NAME="linux"
+
+COPY prebuildfs /
+SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
+# Install required system packages and dependencies
+RUN install_packages ca-certificates curl libgcc-s1 libgomp1 libssl3 libstdc++6 procps
+RUN --mount=type=secret,id=downloads_url,env=SECRET_DOWNLOADS_URL \
+    DOWNLOADS_URL=${SECRET_DOWNLOADS_URL:-${DOWNLOADS_URL}} ; \
+    mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
+    COMPONENTS=( \
+      "wait-for-port-1.0.10-10-linux-${OS_ARCH}-debian-12" \
+      "redis-8.6.3-0-linux-${OS_ARCH}-debian-12" \
+    ) ; \
+    for COMPONENT in "${COMPONENTS[@]}"; do \
+      if [ ! -f "${COMPONENT}.tar.gz" ]; then \
+        curl -SsLf "https://${DOWNLOADS_URL}/${COMPONENT}.tar.gz" -O ; \
+        curl -SsLf "https://${DOWNLOADS_URL}/${COMPONENT}.tar.gz.sha256" -O ; \
+      fi ; \
+      sha256sum -c "${COMPONENT}.tar.gz.sha256" ; \
+      tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner ; \
+      rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
+    done
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+RUN chmod g+rwX /opt/bitnami
+RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
+RUN uninstall_packages curl
+
+COPY rootfs /
+RUN /opt/bitnami/scripts/redis-cluster/postunpack.sh
+ENV APP_VERSION="8.6.3" \
+    BITNAMI_APP_NAME="redis-cluster" \
+    IMAGE_REVISION="3" \
+    PATH="/opt/bitnami/common/bin:/opt/bitnami/redis/bin:$PATH"
+
+EXPOSE 6379
+
+USER 1001
+ENTRYPOINT [ "/opt/bitnami/scripts/redis-cluster/entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/redis-cluster/run.sh" ]

--- a/bitnami/redis-cluster/8.6/debian-12/docker-compose.yml
+++ b/bitnami/redis-cluster/8.6/debian-12/docker-compose.yml
@@ -1,0 +1,74 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+services:
+  redis-node-0:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-0:/bitnami/redis/data
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-1:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-1:/bitnami/redis/data
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-2:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-2:/bitnami/redis/data
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-3:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-3:/bitnami/redis/data
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-4:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-4:/bitnami/redis/data
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-5:
+    image: docker.io/bitnami/redis-cluster:8.6
+    volumes:
+      - redis-cluster_data-5:/bitnami/redis/data
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+    environment:
+      - 'REDIS_PASSWORD=bitnami'
+      - 'REDISCLI_AUTH=bitnami'
+      - 'REDIS_CLUSTER_REPLICAS=1'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+      - 'REDIS_CLUSTER_CREATOR=yes'
+
+volumes:
+  redis-cluster_data-0:
+    driver: local
+  redis-cluster_data-1:
+    driver: local
+  redis-cluster_data-2:
+    driver: local
+  redis-cluster_data-3:
+    driver: local
+  redis-cluster_data-4:
+    driver: local
+  redis-cluster_data-5:
+    driver: local

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/licenses/licenses.txt
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/licenses/licenses.txt
@@ -1,0 +1,2 @@
+Bitnami containers ship with software bundles. You can find the licenses under:
+/opt/bitnami/[name-of-bundle]/licenses/[bundle-version].txt

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Bitnami custom library
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+
+# Constants
+BOLD='\033[1m'
+
+# Functions
+
+########################
+# Print the welcome page
+# Globals:
+#   DISABLE_WELCOME_MESSAGE
+#   BITNAMI_APP_NAME
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+print_welcome_page() {
+    if [[ -z "${DISABLE_WELCOME_MESSAGE:-}" ]]; then
+        if [[ -n "$BITNAMI_APP_NAME" ]]; then
+            print_image_welcome_page
+        fi
+    fi
+}
+
+########################
+# Print the welcome page for a Bitnami Docker image
+# Globals:
+#   BITNAMI_APP_NAME
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+print_image_welcome_page() {
+    local github_url="https://github.com/bitnami/containers"
+
+    info ""
+    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info ""
+}
+

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libfile.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libfile.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for managing files
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/libos.sh
+
+# Functions
+
+########################
+# Replace a regex-matching string in a file
+# Arguments:
+#   $1 - filename
+#   $2 - match regex
+#   $3 - substitute regex
+#   $4 - use POSIX regex. Default: true
+# Returns:
+#   None
+#########################
+replace_in_file() {
+    local filename="${1:?filename is required}"
+    local match_regex="${2:?match regex is required}"
+    local substitute_regex="${3:?substitute regex is required}"
+    local posix_regex=${4:-true}
+
+    local result
+
+    # We should avoid using 'sed in-place' substitutions
+    # 1) They are not compatible with files mounted from ConfigMap(s)
+    # 2) We found incompatibility issues with Debian10 and "in-place" substitutions
+    local -r del=$'\001' # Use a non-printable character as a 'sed' delimiter to avoid issues
+    if [[ $posix_regex = true ]]; then
+        result="$(sed -E "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
+    else
+        result="$(sed "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
+    fi
+    echo "$result" > "$filename"
+}
+
+########################
+# Replace a regex-matching multiline string in a file
+# Arguments:
+#   $1 - filename
+#   $2 - match regex
+#   $3 - substitute regex
+# Returns:
+#   None
+#########################
+replace_in_file_multiline() {
+    local filename="${1:?filename is required}"
+    local match_regex="${2:?match regex is required}"
+    local substitute_regex="${3:?substitute regex is required}"
+
+    local result
+    local -r del=$'\001' # Use a non-printable character as a 'sed' delimiter to avoid issues
+    result="$(perl -pe "BEGIN{undef $/;} s${del}${match_regex}${del}${substitute_regex}${del}sg" "$filename")"
+    echo "$result" > "$filename"
+}
+
+########################
+# Remove a line in a file based on a regex
+# Arguments:
+#   $1 - filename
+#   $2 - match regex
+#   $3 - use POSIX regex. Default: true
+# Returns:
+#   None
+#########################
+remove_in_file() {
+    local filename="${1:?filename is required}"
+    local match_regex="${2:?match regex is required}"
+    local posix_regex=${3:-true}
+    local result
+
+    # We should avoid using 'sed in-place' substitutions
+    # 1) They are not compatible with files mounted from ConfigMap(s)
+    # 2) We found incompatibility issues with Debian10 and "in-place" substitutions
+    if [[ $posix_regex = true ]]; then
+        result="$(sed -E "/$match_regex/d" "$filename")"
+    else
+        result="$(sed "/$match_regex/d" "$filename")"
+    fi
+    echo "$result" > "$filename"
+}
+
+########################
+# Appends text after the last line matching a pattern
+# Arguments:
+#   $1 - file
+#   $2 - match regex
+#   $3 - contents to add
+# Returns:
+#   None
+#########################
+append_file_after_last_match() {
+    local file="${1:?missing file}"
+    local match_regex="${2:?missing pattern}"
+    local value="${3:?missing value}"
+
+    # We read the file in reverse, replace the first match (0,/pattern/s) and then reverse the results again
+    result="$(tac "$file" | sed -E "0,/($match_regex)/s||${value}\n\1|" | tac)"
+    echo "$result" > "$file"
+}
+
+########################
+# Wait until certain entry is present in a log file
+# Arguments:
+#   $1 - entry to look for
+#   $2 - log file
+#   $3 - max retries. Default: 12
+#   $4 - sleep between retries (in seconds). Default: 5
+# Returns:
+#   Boolean
+#########################
+wait_for_log_entry() {
+    local -r entry="${1:-missing entry}"
+    local -r log_file="${2:-missing log file}"
+    local -r retries="${3:-12}"
+    local -r interval_time="${4:-5}"
+    local attempt=0
+
+    check_log_file_for_entry() {
+        if ! grep -qE "$entry" "$log_file"; then
+            debug "Entry \"${entry}\" still not present in ${log_file} (attempt $((++attempt))/${retries})"
+            return 1
+        fi
+    }
+    debug "Checking that ${log_file} log file contains entry \"${entry}\""
+    if retry_while check_log_file_for_entry "$retries" "$interval_time"; then
+        debug "Found entry \"${entry}\" in ${log_file}"
+        true
+    else
+        error "Could not find entry \"${entry}\" in ${log_file} after ${retries} retries"
+        debug_execute cat "$log_file"
+        return 1
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libfs.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libfs.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for file system actions
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+
+# Functions
+
+########################
+# Ensure a file/directory is owned (user and group) but the given user
+# Arguments:
+#   $1 - filepath
+#   $2 - owner
+# Returns:
+#   None
+#########################
+owned_by() {
+    local path="${1:?path is missing}"
+    local owner="${2:?owner is missing}"
+    local group="${3:-}"
+
+    if [[ -n $group ]]; then
+        chown "$owner":"$group" "$path"
+    else
+        chown "$owner":"$owner" "$path"
+    fi
+}
+
+########################
+# Ensure a directory exists and, optionally, is owned by the given user
+# Arguments:
+#   $1 - directory
+#   $2 - owner
+# Returns:
+#   None
+#########################
+ensure_dir_exists() {
+    local dir="${1:?directory is missing}"
+    local owner_user="${2:-}"
+    local owner_group="${3:-}"
+
+    [ -d "${dir}" ] || mkdir -p "${dir}"
+    if [[ -n $owner_user ]]; then
+        owned_by "$dir" "$owner_user" "$owner_group"
+    fi
+}
+
+########################
+# Checks whether a directory is empty or not
+# arguments:
+#   $1 - directory
+# returns:
+#   boolean
+#########################
+is_dir_empty() {
+    local -r path="${1:?missing directory}"
+    # Calculate real path in order to avoid issues with symlinks
+    local -r dir="$(realpath "$path")"
+    if [[ ! -e "$dir" ]] || [[ -z "$(ls -A "$dir")" ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Checks whether a mounted directory is empty or not
+# arguments:
+#   $1 - directory
+# returns:
+#   boolean
+#########################
+is_mounted_dir_empty() {
+    local dir="${1:?missing directory}"
+
+    if is_dir_empty "$dir" || find "$dir" -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" -exec false {} +; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Checks whether a file can be written to or not
+# arguments:
+#   $1 - file
+# returns:
+#   boolean
+#########################
+is_file_writable() {
+    local file="${1:?missing file}"
+    local dir
+    dir="$(dirname "$file")"
+
+    if [[ (-f "$file" && -w "$file") || (! -f "$file" && -d "$dir" && -w "$dir") ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Relativize a path
+# arguments:
+#   $1 - path
+#   $2 - base
+# returns:
+#   None
+#########################
+relativize() {
+    local -r path="${1:?missing path}"
+    local -r base="${2:?missing base}"
+    pushd "$base" >/dev/null || exit
+    realpath -q --no-symlinks --relative-base="$base" "$path" | sed -e 's|^/$|.|' -e 's|^/||'
+    popd >/dev/null || exit
+}
+
+########################
+# Configure permissions and ownership recursively
+# Globals:
+#   None
+# Arguments:
+#   $1 - paths (as a string).
+# Flags:
+#   -f|--file-mode - mode for directories.
+#   -d|--dir-mode - mode for files.
+#   -u|--user - user
+#   -g|--group - group
+# Returns:
+#   None
+#########################
+configure_permissions_ownership() {
+    local -r paths="${1:?paths is missing}"
+    local dir_mode=""
+    local file_mode=""
+    local user=""
+    local group=""
+
+    # Validate arguments
+    shift 1
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        -f | --file-mode)
+            shift
+            file_mode="${1:?missing mode for files}"
+            ;;
+        -d | --dir-mode)
+            shift
+            dir_mode="${1:?missing mode for directories}"
+            ;;
+        -u | --user)
+            shift
+            user="${1:?missing user}"
+            ;;
+        -g | --group)
+            shift
+            group="${1:?missing group}"
+            ;;
+        *)
+            echo "Invalid command line flag $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+
+    read -r -a filepaths <<<"$paths"
+    for p in "${filepaths[@]}"; do
+        if [[ -e "$p" ]]; then
+            find -L "$p" -printf ""
+            if [[ -n $dir_mode ]]; then
+                find -L "$p" -type d ! -perm "$dir_mode" -print0 | xargs -r -0 chmod "$dir_mode"
+            fi
+            if [[ -n $file_mode ]]; then
+                find -L "$p" -type f ! -perm "$file_mode" -print0 | xargs -r -0 chmod "$file_mode"
+            fi
+            if [[ -n $user ]] && [[ -n $group ]]; then
+                find -L "$p" -print0 | xargs -r -0 chown "${user}:${group}"
+            elif [[ -n $user ]] && [[ -z $group ]]; then
+                find -L "$p" -print0 | xargs -r -0 chown "${user}"
+            elif [[ -z $user ]] && [[ -n $group ]]; then
+                find -L "$p" -print0 | xargs -r -0 chgrp "${group}"
+            fi
+        else
+            stderr_print "$p does not exist"
+        fi
+    done
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libhook.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libhook.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library to use for scripts expected to be used as Kubernetes lifecycle hooks
+
+# shellcheck disable=SC1091
+
+# Load generic libraries
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libos.sh
+
+# Override functions that log to stdout/stderr of the current process, so they print to process 1
+for function_to_override in stderr_print debug_execute; do
+    # Output is sent to output of process 1 and thus end up in the container log
+    # The hook output in general isn't saved
+    eval "$(declare -f "$function_to_override") >/proc/1/fd/1 2>/proc/1/fd/2"
+done

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/liblog.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/liblog.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for logging functions
+
+# Constants
+RESET='\033[0m'
+RED='\033[38;5;1m'
+GREEN='\033[38;5;2m'
+YELLOW='\033[38;5;3m'
+MAGENTA='\033[38;5;5m'
+CYAN='\033[38;5;6m'
+
+# Functions
+
+########################
+# Print to STDERR
+# Arguments:
+#   Message to print
+# Returns:
+#   None
+#########################
+stderr_print() {
+    # 'is_boolean_yes' is defined in libvalidations.sh, but depends on this file so we cannot source it
+    local bool="${BITNAMI_QUIET:-false}"
+    # converts the string to lowercase
+    local bool_val="${bool,,}"
+    if ! [[ "$bool_val" = 1 || "$bool_val" =~ ^(yes|true)$ ]]; then
+        printf "%b\\n" "${*}" >&2
+    fi
+}
+
+########################
+# Log message
+# Arguments:
+#   Message to log
+# Returns:
+#   None
+#########################
+log() {
+    local color_bool="${BITNAMI_COLOR:-true}"
+    # converts the string to lowercase
+    local color_bool_val="${color_bool,,}"
+    if [[ "$color_bool_val" = 1 || "$color_bool_val" =~ ^(yes|true)$ ]]; then
+        stderr_print "${CYAN}${MODULE:-} ${MAGENTA}$(date "+%T.%2N ")${RESET}${*}"
+    else
+        stderr_print "${MODULE:-} $(date "+%T.%2N ")${*}"
+    fi
+}
+########################
+# Log an 'info' message
+# Arguments:
+#   Message to log
+# Returns:
+#   None
+#########################
+info() {
+    local msg_color=""
+    local color_bool="${BITNAMI_COLOR:-true}"
+    # converts the string to lowercase
+    local color_bool_val="${color_bool,,}"
+    if [[ "$color_bool_val" = 1 || "$color_bool_val" =~ ^(yes|true)$ ]]; then
+        msg_color="$GREEN"
+    fi
+    log "${msg_color}INFO ${RESET} ==> ${*}"
+}
+########################
+# Log message
+# Arguments:
+#   Message to log
+# Returns:
+#   None
+#########################
+warn() {
+    local msg_color=""
+    local color_bool="${BITNAMI_COLOR:-true}"
+    # converts the string to lowercase
+    local color_bool_val="${color_bool,,}"
+    if [[ "$color_bool_val" = 1 || "$color_bool_val" =~ ^(yes|true)$ ]]; then
+        msg_color="$YELLOW"
+    fi
+    log "${msg_color}WARN ${RESET} ==> ${*}"
+}
+########################
+# Log an 'error' message
+# Arguments:
+#   Message to log
+# Returns:
+#   None
+#########################
+error() {
+    local msg_color=""
+    local color_bool="${BITNAMI_COLOR:-true}"
+    # converts the string to lowercase
+    local color_bool_val="${color_bool,,}"
+    if [[ "$color_bool_val" = 1 || "$color_bool_val" =~ ^(yes|true)$ ]]; then
+        msg_color="$RED"
+    fi
+    log "${msg_color}ERROR${RESET} ==> ${*}"
+}
+########################
+# Log a 'debug' message
+# Globals:
+#   BITNAMI_DEBUG
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+debug() {
+    local msg_color=""
+    local color_bool="${BITNAMI_COLOR:-true}"
+    # converts the string to lowercase
+    local color_bool_val="${color_bool,,}"
+    if [[ "$color_bool_val" = 1 || "$color_bool_val" =~ ^(yes|true)$ ]]; then
+        msg_color="$MAGENTA"
+    fi
+    local debug_bool="${BITNAMI_DEBUG:-false}"
+    if [[ "$debug_bool" = 1 || "$debug_bool" =~ ^(yes|true)$ ]]; then
+        log "${msg_color}DEBUG${RESET} ==> ${*}"
+    fi
+}
+
+########################
+# Indent a string
+# Arguments:
+#   $1 - string
+#   $2 - number of indentation characters (default: 4)
+#   $3 - indentation character (default: " ")
+# Returns:
+#   None
+#########################
+indent() {
+    local string="${1:-}"
+    local num="${2:?missing num}"
+    local char="${3:-" "}"
+    # Build the indentation unit string
+    local indent_unit=""
+    for ((i = 0; i < num; i++)); do
+        indent_unit="${indent_unit}${char}"
+    done
+    # shellcheck disable=SC2001
+    # Complex regex, see https://github.com/koalaman/shellcheck/wiki/SC2001#exceptions
+    echo "$string" | sed "s/^/${indent_unit}/"
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libnet.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libnet.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for network functions
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libvalidations.sh
+
+# Functions
+
+########################
+# Resolve IP address for a host/domain (i.e. DNS lookup)
+# Arguments:
+#   $1 - Hostname to resolve
+#   $2 - IP address version (v4, v6), leave empty for resolving to any version
+# Returns:
+#   IP
+#########################
+dns_lookup() {
+    local host="${1:?host is missing}"
+    local ip_version="${2:-}"
+    getent "ahosts${ip_version}" "$host" | awk '/STREAM/ {print $1 }' | head -n 1
+}
+
+#########################
+# Wait for a hostname and return the IP
+# Arguments:
+#   $1 - hostname
+#   $2 - number of retries
+#   $3 - seconds to wait between retries
+# Returns:
+#   - IP address that corresponds to the hostname
+#########################
+wait_for_dns_lookup() {
+    local hostname="${1:?hostname is missing}"
+    local retries="${2:-5}"
+    local seconds="${3:-1}"
+    check_host() {
+        if [[ $(dns_lookup "$hostname") == "" ]]; then
+            false
+        else
+            true
+        fi
+    }
+    # Wait for the host to be ready
+    retry_while "check_host ${hostname}" "$retries" "$seconds"
+    dns_lookup "$hostname"
+}
+
+########################
+# Get machine's IP
+# Arguments:
+#   None
+# Returns:
+#   Machine IP
+#########################
+get_machine_ip() {
+    local -a ip_addresses
+    local hostname
+    hostname="$(hostname)"
+    read -r -a ip_addresses <<< "$(dns_lookup "$hostname" | xargs echo)"
+    if [[ "${#ip_addresses[@]}" -gt 1 ]]; then
+        warn "Found more than one IP address associated to hostname ${hostname}: ${ip_addresses[*]}, will use ${ip_addresses[0]}"
+    elif [[ "${#ip_addresses[@]}" -lt 1 ]]; then
+        error "Could not find any IP address associated to hostname ${hostname}"
+        exit 1
+    fi
+    # Check if the first IP address is IPv6 to add brackets
+    if validate_ipv6 "${ip_addresses[0]}" ; then
+        echo "[${ip_addresses[0]}]"
+    else
+        echo "${ip_addresses[0]}"
+    fi
+}
+
+########################
+# Check if the provided argument is a resolved hostname
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_hostname_resolved() {
+    local -r host="${1:?missing value}"
+    if [[ -n "$(dns_lookup "$host")" ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Parse URL
+# Globals:
+#   None
+# Arguments:
+#   $1 - uri - String
+#   $2 - component to obtain. Valid options (scheme, authority, userinfo, host, port, path, query or fragment) - String
+# Returns:
+#   String
+parse_uri() {
+    local uri="${1:?uri is missing}"
+    local component="${2:?component is missing}"
+
+    # Solution based on https://tools.ietf.org/html/rfc3986#appendix-B with
+    # additional sub-expressions to split authority into userinfo, host and port
+    # Credits to Patryk Obara (see https://stackoverflow.com/a/45977232/6694969)
+    local -r URI_REGEX='^(([^:/?#]+):)?(//((([^@/?#]+)@)?([^:/?#]+|\[[0-9a-fA-F:.]+\])(:([0-9]+))?))?(/([^?#]*))?(\?([^#]*))?(#(.*))?'
+    #                    ||            |  |||            |         | |            | |         |  |        | |
+    #                    |2 scheme     |  ||6 userinfo   7 host    | 9 port       | 11 rpath  |  13 query | 15 fragment
+    #                    1 scheme:     |  |5 userinfo@             8 :...         10 path     12 ?...     14 #...
+    #                                  |  4 authority
+    #                                  3 //...
+    local index=0
+    case "$component" in
+        scheme)
+            index=2
+            ;;
+        authority)
+            index=4
+            ;;
+        userinfo)
+            index=6
+            ;;
+        host)
+            index=7
+            ;;
+        port)
+            index=9
+            ;;
+        path)
+            index=10
+            ;;
+        query)
+            index=13
+            ;;
+        fragment)
+            index=14
+            ;;
+        *)
+            stderr_print "unrecognized component $component"
+            return 1
+            ;;
+    esac
+    [[ "$uri" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[${index}]}"
+}
+
+########################
+# Wait for a HTTP connection to succeed
+# Globals:
+#   *
+# Arguments:
+#   $1 - URL to wait for
+#   $2 - Maximum amount of retries (optional)
+#   $3 - Time between retries (optional)
+# Returns:
+#   true if the HTTP connection succeeded, false otherwise
+#########################
+wait_for_http_connection() {
+    local url="${1:?missing url}"
+    local retries="${2:-}"
+    local sleep_time="${3:-}"
+    if ! retry_while "debug_execute curl --silent ${url}" "$retries" "$sleep_time"; then
+        error "Could not connect to ${url}"
+        return 1
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -1,0 +1,657 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for operating system actions
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libfs.sh
+. /opt/bitnami/scripts/libvalidations.sh
+
+# Functions
+
+########################
+# Check if an user exists in the system
+# Arguments:
+#   $1 - user
+# Returns:
+#   Boolean
+#########################
+user_exists() {
+    local user="${1:?user is missing}"
+    id "$user" >/dev/null 2>&1
+}
+
+########################
+# Check if a group exists in the system
+# Arguments:
+#   $1 - group
+# Returns:
+#   Boolean
+#########################
+group_exists() {
+    local group="${1:?group is missing}"
+    getent group "$group" >/dev/null 2>&1
+}
+
+########################
+# Create a group in the system if it does not exist already
+# Arguments:
+#   $1 - group
+# Flags:
+#   -i|--gid - the ID for the new group
+#   -s|--system - Whether to create new user as system user (uid <= 999)
+# Returns:
+#   None
+#########################
+ensure_group_exists() {
+    local group="${1:?group is missing}"
+    local gid=""
+    local is_system_user=false
+
+    # Validate arguments
+    shift 1
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        -i | --gid)
+            shift
+            gid="${1:?missing gid}"
+            ;;
+        -s | --system)
+            is_system_user=true
+            ;;
+        *)
+            echo "Invalid command line flag $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+
+    if ! group_exists "$group"; then
+        local -a args=("$group")
+        if [[ -n "$gid" ]]; then
+            if group_exists "$gid"; then
+                error "The GID $gid is already in use." >&2
+                return 1
+            fi
+            args+=("--gid" "$gid")
+        fi
+        $is_system_user && args+=("--system")
+        groupadd "${args[@]}" >/dev/null 2>&1
+    fi
+}
+
+########################
+# Create an user in the system if it does not exist already
+# Arguments:
+#   $1 - user
+# Flags:
+#   -i|--uid - the ID for the new user
+#   -g|--group - the group the new user should belong to
+#   -a|--append-groups - comma-separated list of supplemental groups to append to the new user
+#   -h|--home - the home directory for the new user
+#   -s|--system - whether to create new user as system user (uid <= 999)
+# Returns:
+#   None
+#########################
+ensure_user_exists() {
+    local user="${1:?user is missing}"
+    local uid=""
+    local group=""
+    local append_groups=""
+    local home=""
+    local is_system_user=false
+
+    # Validate arguments
+    shift 1
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        -i | --uid)
+            shift
+            uid="${1:?missing uid}"
+            ;;
+        -g | --group)
+            shift
+            group="${1:?missing group}"
+            ;;
+        -a | --append-groups)
+            shift
+            append_groups="${1:?missing append_groups}"
+            ;;
+        -h | --home)
+            shift
+            home="${1:?missing home directory}"
+            ;;
+        -s | --system)
+            is_system_user=true
+            ;;
+        *)
+            echo "Invalid command line flag $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+
+    if ! user_exists "$user"; then
+        local -a user_args=("-N" "$user")
+        if [[ -n "$uid" ]]; then
+            if user_exists "$uid"; then
+                error "The UID $uid is already in use."
+                return 1
+            fi
+            user_args+=("--uid" "$uid")
+        else
+            $is_system_user && user_args+=("--system")
+        fi
+        useradd "${user_args[@]}" >/dev/null 2>&1
+    fi
+
+    if [[ -n "$group" ]]; then
+        local -a group_args=("$group")
+        $is_system_user && group_args+=("--system")
+        ensure_group_exists "${group_args[@]}"
+        usermod -g "$group" "$user" >/dev/null 2>&1
+    fi
+
+    if [[ -n "$append_groups" ]]; then
+        local -a groups
+        read -ra groups <<<"$(tr ',;' ' ' <<<"$append_groups")"
+        for group in "${groups[@]}"; do
+            ensure_group_exists "$group"
+            usermod -aG "$group" "$user" >/dev/null 2>&1
+        done
+    fi
+
+    if [[ -n "$home" ]]; then
+        mkdir -p "$home"
+        usermod -d "$home" "$user" >/dev/null 2>&1
+        configure_permissions_ownership "$home" -d "775" -f "664" -u "$user" -g "$group"
+    fi
+}
+
+########################
+# Check if the script is currently running as root
+# Arguments:
+#   $1 - user
+#   $2 - group
+# Returns:
+#   Boolean
+#########################
+am_i_root() {
+    if [[ "$(id -u)" = "0" ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Print OS metadata
+# Arguments:
+#   $1 - Flag name
+# Flags:
+#   --id - Distro ID
+#   --version - Distro version
+#   --branch - Distro branch
+#   --codename - Distro codename
+#   --name - Distro name
+#   --pretty-name - Distro pretty name
+# Returns:
+#   String
+#########################
+get_os_metadata() {
+    local -r flag_name="${1:?missing flag}"
+    # Helper function
+    get_os_release_metadata() {
+        local -r env_name="${1:?missing environment variable name}"
+        (
+            . /etc/os-release
+            echo "${!env_name}"
+        )
+    }
+    case "$flag_name" in
+    --id)
+        get_os_release_metadata ID
+        ;;
+    --version)
+        get_os_release_metadata VERSION_ID
+        ;;
+    --branch)
+        get_os_release_metadata VERSION_ID | sed 's/\..*//'
+        ;;
+    --codename)
+        get_os_release_metadata VERSION_CODENAME
+        ;;
+    --name)
+        get_os_release_metadata NAME
+        ;;
+    --pretty-name)
+        get_os_release_metadata PRETTY_NAME
+        ;;
+    *)
+        error "Unknown flag ${flag_name}"
+        return 1
+        ;;
+    esac
+}
+
+########################
+# Get total memory available
+# Arguments:
+#   None
+# Returns:
+#   Memory in bytes
+#########################
+get_total_memory() {
+    echo $(($(grep MemTotal /proc/meminfo | awk '{print $2}') / 1024))
+}
+
+########################
+# Get machine size depending on specified memory
+# Globals:
+#   None
+# Arguments:
+#   None
+# Flags:
+#   --memory - memory size (optional)
+# Returns:
+#   Detected instance size
+#########################
+get_machine_size() {
+    local memory=""
+    # Validate arguments
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+        --memory)
+            shift
+            memory="${1:?missing memory}"
+            ;;
+        *)
+            echo "Invalid command line flag $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+    if [[ -z "$memory" ]]; then
+        debug "Memory was not specified, detecting available memory automatically"
+        memory="$(get_total_memory)"
+    fi
+    sanitized_memory=$(convert_to_mb "$memory")
+    if [[ "$sanitized_memory" -gt 26000 ]]; then
+        echo 2xlarge
+    elif [[ "$sanitized_memory" -gt 13000 ]]; then
+        echo xlarge
+    elif [[ "$sanitized_memory" -gt 6000 ]]; then
+        echo large
+    elif [[ "$sanitized_memory" -gt 3000 ]]; then
+        echo medium
+    elif [[ "$sanitized_memory" -gt 1500 ]]; then
+        echo small
+    else
+        echo micro
+    fi
+}
+
+########################
+# Get machine size depending on specified memory
+# Globals:
+#   None
+# Arguments:
+#   $1 - memory size (optional)
+# Returns:
+#   Detected instance size
+#########################
+get_supported_machine_sizes() {
+    echo micro small medium large xlarge 2xlarge
+}
+
+########################
+# Convert memory size from string to amount of megabytes (i.e. 2G -> 2048)
+# Globals:
+#   None
+# Arguments:
+#   $1 - memory size
+# Returns:
+#   Result of the conversion
+#########################
+convert_to_mb() {
+    local amount="${1:-}"
+    if [[ $amount =~ ^([0-9]+)(m|M|g|G) ]]; then
+        size="${BASH_REMATCH[1]}"
+        unit="${BASH_REMATCH[2]}"
+        if [[ "$unit" = "g" || "$unit" = "G" ]]; then
+            amount="$((size * 1024))"
+        else
+            amount="$size"
+        fi
+    fi
+    echo "$amount"
+}
+
+#########################
+# Redirects output to /dev/null if debug mode is disabled
+# Globals:
+#   BITNAMI_DEBUG
+# Arguments:
+#   $@ - Command to execute
+# Returns:
+#   None
+#########################
+debug_execute() {
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
+        "$@"
+    else
+        "$@" >/dev/null 2>&1
+    fi
+}
+
+########################
+# Retries a command a given number of times
+# Arguments:
+#   $1 - cmd (as a string)
+#   $2 - max retries. Default: 12
+#   $3 - sleep between retries (in seconds). Default: 5
+# Returns:
+#   Boolean
+#########################
+retry_while() {
+    local cmd="${1:?cmd is missing}"
+    local retries="${2:-12}"
+    local sleep_time="${3:-5}"
+    local return_value=1
+
+    read -r -a command <<<"$cmd"
+    for ((i = 1; i <= retries; i += 1)); do
+        "${command[@]}" && return_value=0 && break
+        sleep "$sleep_time"
+    done
+    return $return_value
+}
+
+########################
+# Generate a random string
+# Arguments:
+#   -t|--type - String type (ascii, alphanumeric, numeric), defaults to ascii
+#   -c|--count - Number of characters, defaults to 32
+# Arguments:
+#   None
+# Returns:
+#   None
+# Returns:
+#   String
+#########################
+generate_random_string() {
+    local type="ascii"
+    local count="32"
+    local filter
+    local result
+    # Validate arguments
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+        -t | --type)
+            shift
+            type="$1"
+            ;;
+        -c | --count)
+            shift
+            count="$1"
+            ;;
+        *)
+            echo "Invalid command line flag $1" >&2
+            return 1
+            ;;
+        esac
+        shift
+    done
+    # Validate type
+    case "$type" in
+    ascii)
+        filter="[:print:]"
+        ;;
+    numeric)
+        filter="0-9"
+        ;;
+    alphanumeric)
+        filter="a-zA-Z0-9"
+        ;;
+    alphanumeric+special|special+alphanumeric)
+        # Limit variety of special characters, so there is a higher chance of containing more alphanumeric characters
+        # Special characters are harder to write, and it could impact the overall UX if most passwords are too complex
+        filter='a-zA-Z0-9:@.,/+!='
+        ;;
+    *)
+        echo "Invalid type ${type}" >&2
+        return 1
+        ;;
+    esac
+    # Obtain count + 10 lines from /dev/urandom to ensure that the resulting string has the expected size
+    # Note there is a very small chance of strings starting with EOL character
+    # Therefore, the higher amount of lines read, this will happen less frequently
+    result="$(head -n "$((count + 10))" /dev/urandom | tr -dc "$filter" | head -c "$count")"
+    echo "$result"
+}
+
+########################
+# Create md5 hash from a string
+# Arguments:
+#   $1 - string
+# Returns:
+#   md5 hash - string
+#########################
+generate_md5_hash() {
+    local -r str="${1:?missing input string}"
+    echo -n "$str" | md5sum | awk '{print $1}'
+}
+
+########################
+# Create sha1 hash from a string
+# Arguments:
+#   $1 - string
+#   $2 - algorithm - 1 (default), 224, 256, 384, 512
+# Returns:
+#   sha1 hash - string
+#########################
+generate_sha_hash() {
+    local -r str="${1:?missing input string}"
+    local -r algorithm="${2:-1}"
+    echo -n "$str" | "sha${algorithm}sum" | awk '{print $1}'
+}
+
+########################
+# Converts a string to its hexadecimal representation
+# Arguments:
+#   $1 - string
+# Returns:
+#   hexadecimal representation of the string
+#########################
+convert_to_hex() {
+    local -r str=${1:?missing input string}
+    local -i iterator
+    local char
+    for ((iterator = 0; iterator < ${#str}; iterator++)); do
+        char=${str:iterator:1}
+        printf '%x' "'${char}"
+    done
+}
+
+########################
+# Get boot time
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   Boot time metadata
+#########################
+get_boot_time() {
+    stat /proc --format=%Y
+}
+
+########################
+# Get machine ID
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   Machine ID
+#########################
+get_machine_id() {
+    local machine_id
+    if [[ -f /etc/machine-id ]]; then
+        machine_id="$(cat /etc/machine-id)"
+    fi
+    if [[ -z "$machine_id" ]]; then
+        # Fallback to the boot-time, which will at least ensure a unique ID in the current session
+        machine_id="$(get_boot_time)"
+    fi
+    echo "$machine_id"
+}
+
+########################
+# Get the root partition's disk device ID (e.g. /dev/sda1)
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   Root partition disk ID
+#########################
+get_disk_device_id() {
+    local device_id=""
+    if grep -q ^/dev /proc/mounts; then
+        device_id="$(grep ^/dev /proc/mounts | awk '$2 == "/" { print $1 }' | tail -1)"
+    fi
+    # If it could not be autodetected, fallback to /dev/sda1 as a default
+    if [[ -z "$device_id" || ! -b "$device_id" ]]; then
+        device_id="/dev/sda1"
+    fi
+    echo "$device_id"
+}
+
+########################
+# Get the root disk device ID (e.g. /dev/sda)
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   Root disk ID
+#########################
+get_root_disk_device_id() {
+    get_disk_device_id | sed -E 's/p?[0-9]+$//'
+}
+
+########################
+# Get the root disk size in bytes
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   Root disk size in bytes
+#########################
+get_root_disk_size() {
+    fdisk -l "$(get_root_disk_device_id)" | grep 'Disk.*bytes' | sed -E 's/.*, ([0-9]+) bytes,.*/\1/' || true
+}
+
+########################
+# Run command as a specific user and group (optional)
+# Arguments:
+#   $1 - USER(:GROUP) to switch to
+#   $2..$n - command to execute
+# Returns:
+#   Exit code of the specified command
+#########################
+run_as_user() {
+    run_chroot "$@"
+}
+
+########################
+# Execute command as a specific user and group (optional),
+# replacing the current process image
+# Arguments:
+#   $1 - USER(:GROUP) to switch to
+#   $2..$n - command to execute
+# Returns:
+#   Exit code of the specified command
+#########################
+exec_as_user() {
+    run_chroot --replace-process "$@"
+}
+
+########################
+# Run a command using chroot
+# Arguments:
+#   $1 - USER(:GROUP) to switch to
+#   $2..$n - command to execute
+# Flags:
+#   -r | --replace-process - Replace the current process image (optional)
+# Returns:
+#   Exit code of the specified command
+#########################
+run_chroot() {
+    local userspec
+    local user
+    local homedir
+    local replace=false
+    local -r cwd="$(pwd)"
+
+    # Parse and validate flags
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -r | --replace-process)
+                replace=true
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                stderr_print "unrecognized flag $1"
+                return 1
+                ;;
+            *)
+                break
+                ;;
+        esac
+        shift
+    done
+
+    # Parse and validate arguments
+    if [[ "$#" -lt 2 ]]; then
+        echo "expected at least 2 arguments"
+        return 1
+    else
+        userspec=$1
+        shift
+
+        # userspec can optionally include the group, so we parse the user
+        user=$(echo "$userspec" | cut -d':' -f1)
+    fi
+
+    if ! am_i_root; then
+        error "Could not switch to '${userspec}': Operation not permitted"
+        return 1
+    fi
+
+    # Get the HOME directory for the user to switch, as chroot does
+    # not properly update this env and some scripts rely on it
+    homedir=$(eval echo "~${user}")
+    if [[ ! -d $homedir ]]; then
+        homedir="${HOME:-/}"
+    fi
+
+    # Obtaining value for "$@" indirectly in order to properly support shell parameter expansion
+    if [[ "$replace" = true ]]; then
+        exec chroot --userspec="$userspec" / bash -c "cd ${cwd}; export HOME=${homedir}; exec \"\$@\"" -- "$@"
+    else
+        chroot --userspec="$userspec" / bash -c "cd ${cwd}; export HOME=${homedir}; exec \"\$@\"" -- "$@"
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libpersistence.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libpersistence.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Bitnami persistence library
+# Used for bringing persistence capabilities to applications that don't have clear separation of data and logic
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/libfs.sh
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libversion.sh
+
+# Functions
+
+########################
+# Persist an application directory
+# Globals:
+#   BITNAMI_ROOT_DIR
+#   BITNAMI_VOLUME_DIR
+# Arguments:
+#   $1 - App folder name
+#   $2 - List of app files to persist
+# Returns:
+#   true if all steps succeeded, false otherwise
+#########################
+persist_app() {
+    local -r app="${1:?missing app}"
+    local -a files_to_restore
+    read -r -a files_to_persist <<< "$(tr ',;:' ' ' <<< "$2")"
+    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
+    # Persist the individual files
+    if [[ "${#files_to_persist[@]}" -le 0 ]]; then
+        warn "No files are configured to be persisted"
+        return
+    fi
+    pushd "$install_dir" >/dev/null || exit
+    local file_to_persist_relative file_to_persist_destination file_to_persist_destination_folder
+    local -r tmp_file="/tmp/perms.acl"
+    for file_to_persist in "${files_to_persist[@]}"; do
+        if [[ ! -f "$file_to_persist" && ! -d "$file_to_persist" ]]; then
+            error "Cannot persist '${file_to_persist}' because it does not exist"
+            return 1
+        fi
+        file_to_persist_relative="$(relativize "$file_to_persist" "$install_dir")"
+        file_to_persist_destination="${persist_dir}/${file_to_persist_relative}"
+        file_to_persist_destination_folder="$(dirname "$file_to_persist_destination")"
+        # Get original permissions for existing files, which will be applied later
+        # Exclude the root directory with 'sed', to avoid issues when copying the entirety of it to a volume
+        getfacl -R "$file_to_persist_relative" | sed -E '/# file: (\..+|[^.])/,$!d' > "$tmp_file"
+        # Copy directories to the volume
+        ensure_dir_exists "$file_to_persist_destination_folder"
+        cp -Lr --preserve=links "$file_to_persist_relative" "$file_to_persist_destination_folder"
+        # Restore permissions
+        pushd "$persist_dir" >/dev/null || exit
+        if am_i_root; then
+            setfacl --restore="$tmp_file"
+        else
+            # When running as non-root, don't change ownership
+            setfacl --restore=<(grep -E -v '^# (owner|group):' "$tmp_file")
+        fi
+        popd >/dev/null || exit
+    done
+    popd >/dev/null || exit
+    rm -f "$tmp_file"
+    # Install the persisted files into the installation directory, via symlinks
+    restore_persisted_app "$@"
+}
+
+########################
+# Restore a persisted application directory
+# Globals:
+#   BITNAMI_ROOT_DIR
+#   BITNAMI_VOLUME_DIR
+#   FORCE_MAJOR_UPGRADE
+# Arguments:
+#   $1 - App folder name
+#   $2 - List of app files to restore
+# Returns:
+#   true if all steps succeeded, false otherwise
+#########################
+restore_persisted_app() {
+    local -r app="${1:?missing app}"
+    local -a files_to_restore
+    read -r -a files_to_restore <<< "$(tr ',;:' ' ' <<< "$2")"
+    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
+    # Restore the individual persisted files
+    if [[ "${#files_to_restore[@]}" -le 0 ]]; then
+        warn "No persisted files are configured to be restored"
+        return
+    fi
+    local file_to_restore_relative file_to_restore_origin file_to_restore_destination
+    for file_to_restore in "${files_to_restore[@]}"; do
+        file_to_restore_relative="$(relativize "$file_to_restore" "$install_dir")"
+        # We use 'realpath --no-symlinks' to ensure that the case of '.' is covered and the directory is removed
+        file_to_restore_origin="$(realpath --no-symlinks "${install_dir}/${file_to_restore_relative}")"
+        file_to_restore_destination="$(realpath --no-symlinks "${persist_dir}/${file_to_restore_relative}")"
+        rm -rf "$file_to_restore_origin"
+        ln -sfn "$file_to_restore_destination" "$file_to_restore_origin"
+    done
+}
+
+########################
+# Check if an application directory was already persisted
+# Globals:
+#   BITNAMI_VOLUME_DIR
+# Arguments:
+#   $1 - App folder name
+# Returns:
+#   true if all steps succeeded, false otherwise
+#########################
+is_app_initialized() {
+    local -r app="${1:?missing app}"
+    local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
+    if ! is_mounted_dir_empty "$persist_dir"; then
+        true
+    else
+        false
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libservice.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libservice.sh
@@ -1,0 +1,426 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for managing services
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/libvalidations.sh
+. /opt/bitnami/scripts/liblog.sh
+
+# Functions
+
+########################
+# Read the provided pid file and returns a PID
+# Arguments:
+#   $1 - Pid file
+# Returns:
+#   PID
+#########################
+get_pid_from_file() {
+    local pid_file="${1:?pid file is missing}"
+
+    if [[ -f "$pid_file" ]]; then
+        if [[ -n "$(< "$pid_file")" ]] && [[ "$(< "$pid_file")" -gt 0 ]]; then
+            echo "$(< "$pid_file")"
+        fi
+    fi
+}
+
+########################
+# Check if a provided PID corresponds to a running service
+# Arguments:
+#   $1 - PID
+# Returns:
+#   Boolean
+#########################
+is_service_running() {
+    local pid="${1:?pid is missing}"
+
+    kill -0 "$pid" 2>/dev/null
+}
+
+########################
+# Stop a service by sending a termination signal to its pid
+# Arguments:
+#   $1 - Pid file
+#   $2 - Signal number (optional)
+# Returns:
+#   None
+#########################
+stop_service_using_pid() {
+    local pid_file="${1:?pid file is missing}"
+    local signal="${2:-}"
+    local pid
+
+    pid="$(get_pid_from_file "$pid_file")"
+    [[ -z "$pid" ]] || ! is_service_running "$pid" && return
+
+    if [[ -n "$signal" ]]; then
+        kill "-${signal}" "$pid"
+    else
+        kill "$pid"
+    fi
+
+    local counter=10
+    while [[ "$counter" -ne 0 ]] && is_service_running "$pid"; do
+        sleep 1
+        counter=$((counter - 1))
+    done
+}
+
+########################
+# Start cron daemon
+# Arguments:
+#   None
+# Returns:
+#   true if started correctly, false otherwise
+#########################
+cron_start() {
+    if [[ -x "/usr/sbin/cron" ]]; then
+        /usr/sbin/cron
+    elif [[ -x "/usr/sbin/crond" ]]; then
+        /usr/sbin/crond
+    else
+        false
+    fi
+}
+
+########################
+# Generate a cron configuration file for a given service
+# Arguments:
+#   $1 - Service name
+#   $2 - Command
+# Flags:
+#   --run-as - User to run as (default: root)
+#   --schedule - Cron schedule configuration (default: * * * * *)
+# Returns:
+#   None
+#########################
+generate_cron_conf() {
+    local service_name="${1:?service name is missing}"
+    local cmd="${2:?command is missing}"
+    local run_as="root"
+    local schedule="* * * * *"
+    local clean="true"
+
+    # Parse optional CLI flags
+    shift 2
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --run-as)
+                shift
+                run_as="$1"
+                ;;
+            --schedule)
+                shift
+                schedule="$1"
+                ;;
+            --no-clean)
+                clean="false"
+                ;;
+            *)
+                echo "Invalid command line flag ${1}" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    mkdir -p /etc/cron.d
+    if "$clean"; then
+        cat > "/etc/cron.d/${service_name}" <<EOF
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+${schedule} ${run_as} ${cmd}
+EOF
+    else
+        echo "${schedule} ${run_as} ${cmd}" >> /etc/cron.d/"$service_name"
+    fi
+}
+
+########################
+# Generate a logrotate configuration file
+# Arguments:
+#   $1 - Service name
+#   $2 - Log files pattern
+# Flags:
+#   --period - Period
+#   --rotations - Number of rotations to store
+#   --extra - Extra options (Optional)
+# Returns:
+#   None
+#########################
+generate_logrotate_conf() {
+    local service_name="${1:?service name is missing}"
+    local log_path="${2:?log path is missing}"
+    local period="weekly"
+    local rotations="150"
+    local extra=""
+    local logrotate_conf_dir="/etc/logrotate.d"
+    local var_name
+    # Parse optional CLI flags
+    shift 2
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --period|--rotations|--extra)
+                var_name="$(echo "$1" | sed -e "s/^--//" -e "s/-/_/g")"
+                shift
+                declare "$var_name"="${1:?"$var_name" is missing}"
+                ;;
+            *)
+                echo "Invalid command line flag ${1}" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+
+    mkdir -p "$logrotate_conf_dir"
+    cat <<EOF | sed '/^\s*$/d' > "${logrotate_conf_dir}/${service_name}"
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+${log_path} {
+  ${period}
+  rotate ${rotations}
+  dateext
+  compress
+  copytruncate
+  missingok
+$(indent "$extra" 2)
+}
+EOF
+}
+
+########################
+# Remove a logrotate configuration file
+# Arguments:
+#   $1 - Service name
+# Returns:
+#   None
+#########################
+remove_logrotate_conf() {
+    local service_name="${1:?service name is missing}"
+    local logrotate_conf_dir="/etc/logrotate.d"
+    rm -f "${logrotate_conf_dir}/${service_name}"
+}
+
+########################
+# Generate a Systemd configuration file
+# Arguments:
+#   $1 - Service name
+# Flags:
+#   --custom-service-content - Custom content to add to the [service] block
+#   --environment - Environment variable to define (multiple --environment options may be passed)
+#   --environment-file - Text file with environment variables (multiple --environment-file options may be passed)
+#   --exec-start - Start command (required)
+#   --exec-start-pre - Pre-start command (optional)
+#   --exec-start-post - Post-start command (optional)
+#   --exec-stop - Stop command (optional)
+#   --exec-reload - Reload command (optional)
+#   --group - System group to start the service with
+#   --name - Service full name (e.g. Apache HTTP Server, defaults to $1)
+#   --restart - When to restart the Systemd service after being stopped (defaults to always)
+#   --pid-file - Service PID file
+#   --standard-output - File where to print stdout output
+#   --standard-error - File where to print stderr output
+#   --success-exit-status - Exit code that indicates a successful shutdown
+#   --type - Systemd unit type (defaults to forking)
+#   --user - System user to start the service with
+#   --working-directory - Working directory at which to start the service
+# Returns:
+#   None
+#########################
+generate_systemd_conf() {
+    local -r service_name="${1:?service name is missing}"
+    local -r systemd_units_dir="/etc/systemd/system"
+    local -r service_file="${systemd_units_dir}/bitnami.${service_name}.service"
+    # Default values
+    local name="$service_name"
+    local type="forking"
+    local user=""
+    local group=""
+    local environment=""
+    local environment_file=""
+    local exec_start=""
+    local exec_start_pre=""
+    local exec_start_post=""
+    local exec_stop=""
+    local exec_reload=""
+    local restart="always"
+    local pid_file=""
+    local standard_output="journal"
+    local standard_error=""
+    local limits_content=""
+    local success_exit_status=""
+    local custom_service_content=""
+    local working_directory=""
+    local timeout_start_sec="2min"
+    local timeout_stop_sec="30s"
+    # Parse CLI flags
+    shift
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --name \
+            | --type \
+            | --user \
+            | --group \
+            | --exec-start \
+            | --exec-stop \
+            | --exec-reload \
+            | --restart \
+            | --pid-file \
+            | --standard-output \
+            | --standard-error \
+            | --success-exit-status \
+            | --custom-service-content \
+            | --working-directory \
+            | --timeout-start-sec \
+            | --timeout-stop-sec \
+            )
+                var_name="$(echo "$1" | sed -e "s/^--//" -e "s/-/_/g")"
+                shift
+                declare "$var_name"="${1:?"${var_name} value is missing"}"
+                ;;
+            --limit-*)
+                [[ -n "$limits_content" ]] && limits_content+=$'\n'
+                var_name="${1//--limit-}"
+                shift
+                limits_content+="Limit${var_name^^}=${1:?"--limit-${var_name} value is missing"}"
+                ;;
+            --exec-start-pre)
+                shift
+                [[ -n "$exec_start_pre" ]] && exec_start_pre+=$'\n'
+                exec_start_pre+="ExecStartPre=${1:?"--exec-start-pre value is missing"}"
+                ;;
+            --exec-start-post)
+                shift
+                [[ -n "$exec_start_post" ]] && exec_start_post+=$'\n'
+                exec_start_post+="ExecStartPost=${1:?"--exec-start-post value is missing"}"
+                ;;
+            --environment)
+                shift
+                # It is possible to add multiple environment lines
+                [[ -n "$environment" ]] && environment+=$'\n'
+                environment+="Environment=${1:?"--environment value is missing"}"
+                ;;
+            --environment-file)
+                shift
+                # It is possible to add multiple environment-file lines
+                [[ -n "$environment_file" ]] && environment_file+=$'\n'
+                environment_file+="EnvironmentFile=${1:?"--environment-file value is missing"}"
+                ;;
+            *)
+                echo "Invalid command line flag ${1}" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+    # Validate inputs
+    local error="no"
+    if [[ -z "$exec_start" ]]; then
+        error "The --exec-start option is required"
+        error="yes"
+    fi
+    if [[ "$error" != "no" ]]; then
+        return 1
+    fi
+    # Generate the Systemd unit
+    cat > "$service_file" <<EOF
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+[Unit]
+Description=Bitnami service for ${name}
+# Starting/stopping the main bitnami service should cause the same effect for this service
+PartOf=bitnami.service
+
+[Service]
+Type=${type}
+EOF
+    if [[ -n "$working_directory" ]]; then
+        cat >> "$service_file" <<< "WorkingDirectory=${working_directory}"
+    fi
+    if [[ -n "$exec_start_pre" ]]; then
+        # This variable may contain multiple ExecStartPre= directives
+        cat >> "$service_file" <<< "$exec_start_pre"
+    fi
+    if [[ -n "$exec_start" ]]; then
+        cat >> "$service_file" <<< "ExecStart=${exec_start}"
+    fi
+    if [[ -n "$exec_start_post" ]]; then
+        # This variable may contain multiple ExecStartPost= directives
+        cat >> "$service_file" <<< "$exec_start_post"
+    fi
+    # Optional stop and reload commands
+    if [[ -n "$exec_stop" ]]; then
+        cat >> "$service_file" <<< "ExecStop=${exec_stop}"
+    fi
+    if [[ -n "$exec_reload" ]]; then
+        cat >> "$service_file" <<< "ExecReload=${exec_reload}"
+    fi
+    # User and group
+    if [[ -n "$user" ]]; then
+        cat >> "$service_file" <<< "User=${user}"
+    fi
+    if [[ -n "$group" ]]; then
+        cat >> "$service_file" <<< "Group=${group}"
+    fi
+    # PID file allows to determine if the main process is running properly (for Restart=always)
+    if [[ -n "$pid_file" ]]; then
+        cat >> "$service_file" <<< "PIDFile=${pid_file}"
+    fi
+    if [[ -n "$restart" ]]; then
+        cat >> "$service_file" <<< "Restart=${restart}"
+    fi
+    # Environment flags
+    if [[ -n "$environment" ]]; then
+        # This variable may contain multiple Environment= directives
+        cat >> "$service_file" <<< "$environment"
+    fi
+    if [[ -n "$environment_file" ]]; then
+        # This variable may contain multiple EnvironmentFile= directives
+        cat >> "$service_file" <<< "$environment_file"
+    fi
+    # Logging
+    if [[ -n "$standard_output" ]]; then
+        cat >> "$service_file" <<< "StandardOutput=${standard_output}"
+    fi
+    if [[ -n "$standard_error" ]]; then
+        cat >> "$service_file" <<< "StandardError=${standard_error}"
+    fi
+    if [[ -n "$custom_service_content" ]]; then
+        # This variable may contain multiple miscellaneous directives
+        cat >> "$service_file" <<< "$custom_service_content"
+    fi
+    if [[ -n "$success_exit_status" ]]; then
+        cat >> "$service_file" <<EOF
+# When the process receives a SIGTERM signal, it exits with code ${success_exit_status}
+SuccessExitStatus=${success_exit_status}
+EOF
+    fi
+    cat >> "$service_file" <<EOF
+# Optimizations
+TimeoutStartSec=${timeout_start_sec}
+TimeoutStopSec=${timeout_stop_sec}
+IgnoreSIGPIPE=no
+KillMode=mixed
+EOF
+    if [[ -n "$limits_content" ]]; then
+        cat >> "$service_file" <<EOF
+# Limits
+${limits_content}
+EOF
+    fi
+    cat >> "$service_file" <<EOF
+
+[Install]
+# Enabling/disabling the main bitnami service should cause the same effect for this service
+WantedBy=bitnami.service
+EOF
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libvalidations.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libvalidations.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Validation functions library
+
+# shellcheck disable=SC1091,SC2086
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+
+# Functions
+
+########################
+# Check if the provided argument is an integer
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_int() {
+    local -r int="${1:?missing value}"
+    if [[ "$int" =~ ^-?[0-9]+ ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is a positive integer
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_positive_int() {
+    local -r int="${1:?missing value}"
+    if is_int "$int" && (( "${int}" >= 0 )); then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is a boolean or is the string 'yes/true'
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_boolean_yes() {
+    local -r bool="${1:-}"
+    # converts the string to lowercase
+    local bool_val="${bool,,}"
+    if [[ "$bool_val" = 1 || "$bool_val" =~ ^(yes|true)$ ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is a boolean yes/no value
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_yes_no_value() {
+    local -r bool="${1:-}"
+    if [[ "$bool" =~ ^(yes|no)$ ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is a boolean true/false value
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_true_false_value() {
+    local -r bool="${1:-}"
+    if [[ "$bool" =~ ^(true|false)$ ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is a boolean 1/0 value
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_1_0_value() {
+    local -r bool="${1:-}"
+    if [[ "$bool" =~ ^[10]$ ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Check if the provided argument is an empty string or not defined
+# Arguments:
+#   $1 - Value to check
+# Returns:
+#   Boolean
+#########################
+is_empty_value() {
+    local -r val="${1:-}"
+    if [[ -z "$val" ]]; then
+        true
+    else
+        false
+    fi
+}
+
+########################
+# Validate if the provided argument is a valid port
+# Arguments:
+#   $1 - Port to validate
+# Returns:
+#   Boolean and error message
+#########################
+validate_port() {
+    local value
+    local unprivileged=0
+
+    # Parse flags
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -unprivileged)
+                unprivileged=1
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                stderr_print "unrecognized flag $1"
+                return 1
+                ;;
+            *)
+                break
+                ;;
+        esac
+        shift
+    done
+
+    if [[ "$#" -gt 1 ]]; then
+        echo "too many arguments provided"
+        return 2
+    elif [[ "$#" -eq 0 ]]; then
+        stderr_print "missing port argument"
+        return 1
+    else
+        value=$1
+    fi
+
+    if [[ -z "$value" ]]; then
+        echo "the value is empty"
+        return 1
+    else
+        if ! is_int "$value"; then
+            echo "value is not an integer"
+            return 2
+        elif [[ "$value" -lt 0 ]]; then
+            echo "negative value provided"
+            return 2
+        elif [[ "$value" -gt 65535 ]]; then
+            echo "requested port is greater than 65535"
+            return 2
+        elif [[ "$unprivileged" = 1 && "$value" -lt 1024 ]]; then
+            echo "privileged port requested"
+            return 3
+        fi
+    fi
+}
+
+########################
+# Validate if the provided argument is a valid IPv6 address
+# Arguments:
+#   $1 - IP to validate
+# Returns:
+#   Boolean
+#########################
+validate_ipv6() {
+    local ip="${1:?ip is missing}"
+    local stat=1
+    local full_address_regex='^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$'
+    local short_address_regex='^((([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}){0,6}::(([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}){0,6})$'
+
+    if [[ $ip =~ $full_address_regex || $ip =~ $short_address_regex || $ip == "::" ]]; then
+        stat=0
+    fi
+    return $stat
+}
+
+########################
+# Validate if the provided argument is a valid IPv4 address
+# Arguments:
+#   $1 - IP to validate
+# Returns:
+#   Boolean
+#########################
+validate_ipv4() {
+    local ip="${1:?ip is missing}"
+    local stat=1
+
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        read -r -a ip_array <<< "$(tr '.' ' ' <<< "$ip")"
+        [[ ${ip_array[0]} -le 255 && ${ip_array[1]} -le 255 \
+            && ${ip_array[2]} -le 255 && ${ip_array[3]} -le 255 ]]
+        stat=$?
+    fi
+    return $stat
+}
+
+########################
+# Validate if the provided argument is a valid IPv4 or IPv6 address
+# Arguments:
+#   $1 - IP to validate
+# Returns:
+#   Boolean
+#########################
+validate_ip() {
+    local ip="${1:?ip is missing}"
+    local stat=1
+
+    if validate_ipv4 "$ip"; then
+        stat=0
+    else
+        stat=$(validate_ipv6 "$ip")
+    fi
+    return $stat
+}
+
+########################
+# Validate a string format
+# Arguments:
+#   $1 - String to validate
+# Returns:
+#   Boolean
+#########################
+validate_string() {
+    local string
+    local min_length=-1
+    local max_length=-1
+
+    # Parse flags
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -min-length)
+                shift
+                min_length=${1:-}
+                ;;
+            -max-length)
+                shift
+                max_length=${1:-}
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                stderr_print "unrecognized flag $1"
+                return 1
+                ;;
+            *)
+                string="$1"
+                ;;
+        esac
+        shift
+    done
+
+    if [[ "$min_length" -ge 0 ]] && [[ "${#string}" -lt "$min_length" ]]; then
+        echo "string length is less than $min_length"
+        return 1
+    fi
+    if [[ "$max_length" -ge 0 ]] && [[ "${#string}" -gt "$max_length" ]]; then
+        echo "string length is great than $max_length"
+        return 1
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libversion.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libversion.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Library for managing versions strings
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/liblog.sh
+
+# Functions
+########################
+# Gets semantic version
+# Arguments:
+#   $1 - version: string to extract major.minor.patch
+#   $2 - section: 1 to extract major, 2 to extract minor, 3 to extract patch
+# Returns:
+#   array with the major, minor and release
+#########################
+get_sematic_version () {
+    local version="${1:?version is required}"
+    local section="${2:?section is required}"
+    local -a version_sections
+
+    #Regex to parse versions: x.y.z
+    local -r regex='([0-9]+)(\.([0-9]+)(\.([0-9]+))?)?'
+
+    if [[ "$version" =~ $regex ]]; then
+        local i=1
+        local j=1
+        local n=${#BASH_REMATCH[*]}
+
+        while [[ $i -lt $n ]]; do
+            if [[ -n "${BASH_REMATCH[$i]}" ]] && [[ "${BASH_REMATCH[$i]:0:1}" != '.' ]];  then
+                version_sections[j]="${BASH_REMATCH[$i]}"
+                ((j++))
+            fi
+            ((i++))
+        done
+
+        local number_regex='^[0-9]+$'
+        if [[ "$section" =~ $number_regex ]] && (( section > 0 )) && (( section <= 3 )); then
+             echo "${version_sections[$section]}"
+             return
+        else
+            stderr_print "Section allowed values are: 1, 2, and 3"
+            return 1
+        fi
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libwebserver.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/opt/bitnami/scripts/libwebserver.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Bitnami web server handler library
+
+# shellcheck disable=SC1090,SC1091
+
+# Load generic libraries
+. /opt/bitnami/scripts/liblog.sh
+
+########################
+# Execute a command (or list of commands) with the web server environment and library loaded
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_execute() {
+    local -r web_server="${1:?missing web server}"
+    shift
+    # Run program in sub-shell to avoid web server environment getting loaded when not necessary
+    (
+        . "/opt/bitnami/scripts/lib${web_server}.sh"
+        . "/opt/bitnami/scripts/${web_server}-env.sh"
+        "$@"
+    )
+}
+
+########################
+# Prints the list of enabled web servers
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_list() {
+    local -r -a supported_web_servers=(apache nginx)
+    local -a existing_web_servers=()
+    for web_server in "${supported_web_servers[@]}"; do
+        [[ -f "/opt/bitnami/scripts/${web_server}-env.sh" ]] && existing_web_servers+=("$web_server")
+    done
+    echo "${existing_web_servers[@]:-}"
+}
+
+########################
+# Prints the currently-enabled web server type (only one, in order of preference)
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_type() {
+    local -a web_servers
+    read -r -a web_servers <<< "$(web_server_list)"
+    echo "${web_servers[0]:-}"
+}
+
+########################
+# Validate that a supported web server is configured
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_validate() {
+    local error_code=0
+    local supported_web_servers=("apache" "nginx")
+
+    # Auxiliary functions
+    print_validation_error() {
+        error "$1"
+        error_code=1
+    }
+
+    if [[ -z "$(web_server_type)" || ! " ${supported_web_servers[*]} " == *" $(web_server_type) "* ]]; then
+        print_validation_error "Could not detect any supported web servers. It must be one of: ${supported_web_servers[*]}"
+    elif ! web_server_execute "$(web_server_type)" type -t "is_$(web_server_type)_running" >/dev/null; then
+        print_validation_error "Could not load the $(web_server_type) web server library from /opt/bitnami/scripts. Check that it exists and is readable."
+    fi
+
+    return "$error_code"
+}
+
+########################
+# Check whether the web server is running
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   true if the web server is running, false otherwise
+#########################
+is_web_server_running() {
+    "is_$(web_server_type)_running"
+}
+
+########################
+# Start web server
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_start() {
+    info "Starting $(web_server_type) in background"
+    if [[ "${BITNAMI_SERVICE_MANAGER:-}" = "systemd" ]]; then
+        systemctl start "bitnami.$(web_server_type).service"
+    else
+        "${BITNAMI_ROOT_DIR}/scripts/$(web_server_type)/start.sh"
+    fi
+}
+
+########################
+# Stop web server
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+web_server_stop() {
+    info "Stopping $(web_server_type)"
+    if [[ "${BITNAMI_SERVICE_MANAGER:-}" = "systemd" ]]; then
+        systemctl stop "bitnami.$(web_server_type).service"
+    else
+        "${BITNAMI_ROOT_DIR}/scripts/$(web_server_type)/stop.sh"
+    fi
+}
+
+########################
+# Ensure a web server application configuration exists (i.e. Apache virtual host format or NGINX server block)
+# It serves as a wrapper for the specific web server function
+# Globals:
+#   *
+# Arguments:
+#   $1 - App name
+# Flags:
+#   --type - Application type, which has an effect on which configuration template to use
+#   --hosts - Host listen addresses
+#   --server-name - Server name
+#   --server-aliases - Server aliases
+#   --allow-remote-connections - Whether to allow remote connections or to require local connections
+#   --disable - Whether to render server configurations with a .disabled prefix
+#   --disable-http - Whether to render the app's HTTP server configuration with a .disabled prefix
+#   --disable-https - Whether to render the app's HTTPS server configuration with a .disabled prefix
+#   --http-port - HTTP port number
+#   --https-port - HTTPS port number
+#   --document-root - Path to document root directory
+# Apache-specific flags:
+#   --apache-additional-configuration - Additional vhost configuration (no default)
+#   --apache-additional-http-configuration - Additional HTTP vhost configuration (no default)
+#   --apache-additional-https-configuration - Additional HTTPS vhost configuration (no default)
+#   --apache-before-vhost-configuration - Configuration to add before the <VirtualHost> directive (no default)
+#   --apache-allow-override - Whether to allow .htaccess files (only allowed when --move-htaccess is set to 'no' and type is not defined)
+#   --apache-extra-directory-configuration - Extra configuration for the document root directory
+#   --apache-proxy-address - Address where to proxy requests
+#   --apache-proxy-configuration - Extra configuration for the proxy
+#   --apache-proxy-http-configuration - Extra configuration for the proxy HTTP vhost
+#   --apache-proxy-https-configuration - Extra configuration for the proxy HTTPS vhost
+#   --apache-move-htaccess - Move .htaccess files to a common place so they can be loaded during Apache startup (only allowed when type is not defined)
+# NGINX-specific flags:
+#   --nginx-additional-configuration - Additional server block configuration (no default)
+#   --nginx-external-configuration - Configuration external to server block (no default)
+# Returns:
+#   true if the configuration was enabled, false otherwise
+########################
+ensure_web_server_app_configuration_exists() {
+    local app="${1:?missing app}"
+    shift
+    local -a apache_args nginx_args web_servers args_var
+    apache_args=("$app")
+    nginx_args=("$app")
+    # Validate arguments
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            # Common flags
+            --disable \
+            | --disable-http \
+            | --disable-https \
+            )
+                apache_args+=("$1")
+                nginx_args+=("$1")
+                ;;
+            --hosts \
+            | --server-name \
+            | --server-aliases \
+            | --type \
+            | --allow-remote-connections \
+            | --http-port \
+            | --https-port \
+            | --document-root \
+            )
+                apache_args+=("$1" "${2:?missing value}")
+                nginx_args+=("$1" "${2:?missing value}")
+                shift
+                ;;
+
+            # Specific Apache flags
+            --apache-additional-configuration \
+            | --apache-additional-http-configuration \
+            | --apache-additional-https-configuration \
+            | --apache-before-vhost-configuration \
+            | --apache-allow-override \
+            | --apache-extra-directory-configuration \
+            | --apache-proxy-address \
+            | --apache-proxy-configuration \
+            | --apache-proxy-http-configuration \
+            | --apache-proxy-https-configuration \
+            | --apache-move-htaccess \
+            )
+                apache_args+=("${1//apache-/}" "${2:?missing value}")
+                shift
+                ;;
+
+            # Specific NGINX flags
+            --nginx-additional-configuration \
+            | --nginx-external-configuration)
+                nginx_args+=("${1//nginx-/}" "${2:?missing value}")
+                shift
+                ;;
+
+            *)
+                echo "Invalid command line flag $1" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+    read -r -a web_servers <<< "$(web_server_list)"
+    for web_server in "${web_servers[@]}"; do
+        args_var="${web_server}_args[@]"
+        web_server_execute "$web_server" "ensure_${web_server}_app_configuration_exists" "${!args_var}"
+    done
+}
+
+########################
+# Ensure a web server application configuration does not exist anymore (i.e. Apache virtual host format or NGINX server block)
+# It serves as a wrapper for the specific web server function
+# Globals:
+#   *
+# Arguments:
+#   $1 - App name
+# Returns:
+#   true if the configuration was disabled, false otherwise
+########################
+ensure_web_server_app_configuration_not_exists() {
+    local app="${1:?missing app}"
+    local -a web_servers
+    read -r -a web_servers <<< "$(web_server_list)"
+    for web_server in "${web_servers[@]}"; do
+        web_server_execute "$web_server" "ensure_${web_server}_app_configuration_not_exists" "$app"
+    done
+}
+
+########################
+# Ensure the web server loads the configuration for an application in a URL prefix
+# It serves as a wrapper for the specific web server function
+# Globals:
+#   *
+# Arguments:
+#   $1 - App name
+# Flags:
+#   --allow-remote-connections - Whether to allow remote connections or to require local connections
+#   --document-root - Path to document root directory
+#   --prefix - URL prefix from where it will be accessible (i.e. /myapp)
+#   --type - Application type, which has an effect on what configuration template will be used
+# Apache-specific flags:
+#   --apache-additional-configuration - Additional vhost configuration (no default)
+#   --apache-allow-override - Whether to allow .htaccess files (only allowed when --move-htaccess is set to 'no')
+#   --apache-extra-directory-configuration - Extra configuration for the document root directory
+#   --apache-move-htaccess - Move .htaccess files to a common place so they can be loaded during Apache startup
+# NGINX-specific flags:
+#   --nginx-additional-configuration - Additional server block configuration (no default)
+# Returns:
+#   true if the configuration was enabled, false otherwise
+########################
+ensure_web_server_prefix_configuration_exists() {
+    local app="${1:?missing app}"
+    shift
+    local -a apache_args nginx_args web_servers args_var
+    apache_args=("$app")
+    nginx_args=("$app")
+    # Validate arguments
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            # Common flags
+            --allow-remote-connections \
+            | --document-root \
+            | --prefix \
+            | --type \
+            )
+                apache_args+=("$1" "${2:?missing value}")
+                nginx_args+=("$1" "${2:?missing value}")
+                shift
+                ;;
+
+            # Specific Apache flags
+            --apache-additional-configuration \
+            | --apache-allow-override \
+            | --apache-extra-directory-configuration \
+            | --apache-move-htaccess \
+            )
+                apache_args+=("${1//apache-/}" "$2")
+                shift
+                ;;
+
+            # Specific NGINX flags
+            --nginx-additional-configuration)
+                nginx_args+=("${1//nginx-/}" "$2")
+                shift
+                ;;
+
+            *)
+                echo "Invalid command line flag $1" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+    read -r -a web_servers <<< "$(web_server_list)"
+    for web_server in "${web_servers[@]}"; do
+        args_var="${web_server}_args[@]"
+        web_server_execute "$web_server" "ensure_${web_server}_prefix_configuration_exists" "${!args_var}"
+    done
+}
+
+########################
+# Ensure a web server application configuration is updated with the runtime configuration (i.e. ports)
+# It serves as a wrapper for the specific web server function
+# Globals:
+#   *
+# Arguments:
+#   $1 - App name
+# Flags:
+#   --hosts - Host listen addresses
+#   --server-name - Server name
+#   --server-aliases - Server aliases
+#   --enable-http - Enable HTTP app configuration (if not enabled already)
+#   --enable-https - Enable HTTPS app configuration (if not enabled already)
+#   --disable-http - Disable HTTP app configuration (if not disabled already)
+#   --disable-https - Disable HTTPS app configuration (if not disabled already)
+#   --http-port - HTTP port number
+#   --https-port - HTTPS port number
+# Returns:
+#   true if the configuration was updated, false otherwise
+########################
+web_server_update_app_configuration() {
+    local app="${1:?missing app}"
+    shift
+    local -a args web_servers
+    args=("$app")
+    # Validate arguments
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            # Common flags
+            --enable-http \
+            | --enable-https \
+            | --disable-http \
+            | --disable-https \
+            )
+                args+=("$1")
+                ;;
+            --hosts \
+            | --server-name \
+            | --server-aliases \
+            | --http-port \
+            | --https-port \
+            )
+                args+=("$1" "${2:?missing value}")
+                shift
+                ;;
+
+            *)
+                echo "Invalid command line flag $1" >&2
+                return 1
+                ;;
+        esac
+        shift
+    done
+    read -r -a web_servers <<< "$(web_server_list)"
+    for web_server in "${web_servers[@]}"; do
+        web_server_execute "$web_server" "${web_server}_update_app_configuration" "${args[@]}"
+    done
+}

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/install_packages
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/install_packages
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -eu
+
+n=0
+max=2
+export DEBIAN_FRONTEND=noninteractive
+
+until [ $n -gt $max ]; do
+    set +e
+    (
+      apt-get update -qq &&
+      apt-get install -y --no-install-recommends "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    n=$(($n + 1))
+done
+apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/run-script
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/run-script
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -u
+
+if [ $# -eq 0 ]; then
+    >&2 echo "No arguments provided"
+    exit 1
+fi
+
+script=$1
+exit_code="${2:-96}"
+fail_if_not_present="${3:-n}"
+
+if test -f "$script"; then
+  sh $script
+
+  if [ $? -ne 0 ]; then
+    exit $((exit_code))
+  fi
+elif [ "$fail_if_not_present" = "y" ]; then
+  >&2 echo "script not found: $script"
+  exit 127
+fi

--- a/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/uninstall_packages
+++ b/bitnami/redis-cluster/8.6/debian-12/prebuildfs/usr/sbin/uninstall_packages
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -eu
+
+n=0
+max=2
+export DEBIAN_FRONTEND=noninteractive
+
+until [ $n -gt $max ]; do
+    set +e
+    (
+        apt-get autoremove --purge -y "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    n=$(($n + 1))
+done
+apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
@@ -1,0 +1,461 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Bitnami Redis library
+
+# shellcheck disable=SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/libfile.sh
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libnet.sh
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/libservice.sh
+. /opt/bitnami/scripts/libvalidations.sh
+
+# Functions
+
+########################
+# Retrieve a configuration setting value
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - key
+#   $2 - conf file
+# Returns:
+#   None
+#########################
+redis_conf_get() {
+    local -r key="${1:?missing key}"
+    local -r conf_file="${2:-"${REDIS_BASE_DIR}/etc/redis.conf"}"
+
+    if grep -q -E "^\s*$key " "$conf_file"; then
+        grep -E "^\s*$key " "$conf_file" | awk '{print $2}'
+    fi
+}
+
+########################
+# Set a configuration setting value
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - key
+#   $2 - value
+# Returns:
+#   None
+#########################
+redis_conf_set() {
+    local -r key="${1:?missing key}"
+    local value="${2:-}"
+
+    # Sanitize inputs
+    value="${value//\\/\\\\}"
+    value="${value//&/\\&}"
+    value="${value//\?/\\?}"
+    value="${value//[$'\t\n\r']}"
+    [[ "$value" = "" ]] && value="\"$value\""
+
+    # Determine whether to enable the configuration for RDB persistence, if yes, do not enable the replacement operation
+    if [ "${key}" == "save" ]; then
+        echo "${key} ${value}" >> "${REDIS_BASE_DIR}/etc/redis.conf"
+    else
+        replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false
+    fi
+}
+
+########################
+# Unset a configuration setting value
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - key
+# Returns:
+#   None
+#########################
+redis_conf_unset() {
+    local -r key="${1:?missing key}"
+    remove_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^\s*$key .*" false
+}
+
+########################
+# Get Redis version
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   None
+# Returns:
+#   Redis versoon
+#########################
+redis_version() {
+    "${REDIS_BASE_DIR}/bin/redis-cli" --version | grep -E -o "[0-9]+.[0-9]+.[0-9]+"
+}
+
+########################
+# Get Redis major version
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   None
+# Returns:
+#   Redis major version
+#########################
+redis_major_version() {
+    redis_version | grep -E -o "^[0-9]+"
+}
+
+########################
+# Check if redis is running
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - pid file
+# Returns:
+#   Boolean
+#########################
+is_redis_running() {
+    local pid_file="${1:-"${REDIS_BASE_DIR}/tmp/redis.pid"}"
+    local pid
+    pid="$(get_pid_from_file "$pid_file")"
+
+    if [[ -z "$pid" ]]; then
+        false
+    else
+        is_service_running "$pid"
+    fi
+}
+
+########################
+# Check if redis is not running
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - pid file
+# Returns:
+#   Boolean
+#########################
+is_redis_not_running() {
+    ! is_redis_running "$@"
+}
+
+########################
+# Stop Redis
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_stop() {
+    local pass
+    local port
+    local args
+
+    ! is_redis_running && return
+    pass="$(redis_conf_get "requirepass")"
+    is_boolean_yes "$REDIS_TLS_ENABLED" && port="$(redis_conf_get "tls-port")" || port="$(redis_conf_get "port")"
+
+    [[ -n "$pass" ]] && args+=("-a" "$pass")
+    [[ "$port" != "0" ]] && args+=("-p" "$port")
+
+    debug "Stopping Redis"
+    if am_i_root; then
+        run_as_user "$REDIS_DAEMON_USER" "${REDIS_BASE_DIR}/bin/redis-cli" "${args[@]}" shutdown
+    else
+        "${REDIS_BASE_DIR}/bin/redis-cli" "${args[@]}" shutdown
+    fi
+}
+
+########################
+# Validate settings in REDIS_* env vars.
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_validate() {
+    debug "Validating settings in REDIS_* env vars.."
+    local error_code=0
+
+    # Auxiliary functions
+    print_validation_error() {
+        error "$1"
+        error_code=1
+    }
+
+    empty_password_enabled_warn() {
+        warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
+    }
+    empty_password_error() {
+        print_validation_error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
+    }
+
+    if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+        empty_password_enabled_warn
+    else
+        [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
+    fi
+    if [[ -n "$REDIS_REPLICATION_MODE" ]]; then
+        if [[ "$REDIS_REPLICATION_MODE" =~ ^(slave|replica)$ ]]; then
+            if [[ -n "$REDIS_MASTER_PORT_NUMBER" ]]; then
+                if ! err=$(validate_port "$REDIS_MASTER_PORT_NUMBER"); then
+                    print_validation_error "An invalid port was specified in the environment variable REDIS_MASTER_PORT_NUMBER: $err"
+                fi
+            fi
+            if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD" && [[ -z "$REDIS_MASTER_PASSWORD" ]]; then
+                empty_password_error REDIS_MASTER_PASSWORD
+            fi
+        elif [[ "$REDIS_REPLICATION_MODE" != "master" ]]; then
+            print_validation_error "Invalid replication mode. Available options are 'master/replica'"
+        fi
+    fi
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        if [[ "$REDIS_PORT_NUMBER" == "$REDIS_TLS_PORT_NUMBER" ]] && [[ "$REDIS_PORT_NUMBER" != "6379" ]]; then
+            # If both ports are assigned the same numbers and they are different to the default settings
+            print_validation_error "Environment variables REDIS_PORT_NUMBER and REDIS_TLS_PORT_NUMBER point to the same port number (${REDIS_PORT_NUMBER}). Change one of them or disable non-TLS traffic by setting REDIS_PORT_NUMBER=0"
+        fi
+        if [[ -z "$REDIS_TLS_CERT_FILE" ]]; then
+            print_validation_error "You must provide a X.509 certificate in order to use TLS"
+        elif [[ ! -f "$REDIS_TLS_CERT_FILE" ]]; then
+            print_validation_error "The X.509 certificate file in the specified path ${REDIS_TLS_CERT_FILE} does not exist"
+        fi
+        if [[ -z "$REDIS_TLS_KEY_FILE" ]]; then
+            print_validation_error "You must provide a private key in order to use TLS"
+        elif [[ ! -f "$REDIS_TLS_KEY_FILE" ]]; then
+            print_validation_error "The private key file in the specified path ${REDIS_TLS_KEY_FILE} does not exist"
+        fi
+        if [[ -z "$REDIS_TLS_CA_FILE" ]]; then
+            if [[ -z "$REDIS_TLS_CA_DIR" ]]; then
+                print_validation_error "You must provide either a CA X.509 certificate or a CA certificates directory in order to use TLS"
+            elif [[ ! -d "$REDIS_TLS_CA_DIR" ]]; then
+                print_validation_error "The CA certificates directory specified by path ${REDIS_TLS_CA_DIR} does not exist"
+            fi
+        elif [[ ! -f "$REDIS_TLS_CA_FILE" ]]; then
+            print_validation_error "The CA X.509 certificate file in the specified path ${REDIS_TLS_CA_FILE} does not exist"
+        fi
+        if [[ -n "$REDIS_TLS_DH_PARAMS_FILE" ]] && [[ ! -f "$REDIS_TLS_DH_PARAMS_FILE" ]]; then
+            print_validation_error "The DH param file in the specified path ${REDIS_TLS_DH_PARAMS_FILE} does not exist"
+        fi
+    fi
+
+    [[ "$error_code" -eq 0 ]] || exit "$error_code"
+}
+
+########################
+# Configure Redis replication
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - Replication mode
+# Returns:
+#   None
+#########################
+redis_configure_replication() {
+    info "Configuring replication mode"
+
+    redis_conf_set replica-announce-ip "${REDIS_REPLICA_IP:-$(get_machine_ip)}"
+    redis_conf_set replica-announce-port "${REDIS_REPLICA_PORT:-$REDIS_MASTER_PORT_NUMBER}"
+    # Use TLS in the replication connections
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-replication yes
+    fi
+    if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
+        if [[ -n "$REDIS_PASSWORD" ]]; then
+            redis_conf_set masterauth "$REDIS_PASSWORD"
+        fi
+    elif [[ "$REDIS_REPLICATION_MODE" =~ ^(slave|replica)$ ]]; then
+        if [[ -n "$REDIS_SENTINEL_HOST" ]]; then
+            local -a sentinel_info_command=("redis-cli" "-h" "${REDIS_SENTINEL_HOST}" "-p" "${REDIS_SENTINEL_PORT_NUMBER}")
+            is_boolean_yes "$REDIS_TLS_ENABLED" && sentinel_info_command+=("--tls" "--cert" "${REDIS_TLS_CERT_FILE}" "--key" "${REDIS_TLS_KEY_FILE}")
+            # shellcheck disable=SC2015
+            is_empty_value "$REDIS_TLS_CA_FILE" && sentinel_info_command+=("--cacertdir" "${REDIS_TLS_CA_DIR}") || sentinel_info_command+=("--cacert" "${REDIS_TLS_CA_FILE}")
+            sentinel_info_command+=("sentinel" "get-master-addr-by-name" "${REDIS_SENTINEL_MASTER_NAME}")
+            read -r -a REDIS_SENTINEL_INFO <<< "$("${sentinel_info_command[@]}" | tr '\n' ' ')"
+            REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
+            REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
+        fi
+        wait-for-port --host "$REDIS_MASTER_HOST" "$REDIS_MASTER_PORT_NUMBER"
+        [[ -n "$REDIS_MASTER_PASSWORD" ]] && redis_conf_set masterauth "$REDIS_MASTER_PASSWORD"
+        # Use 'replicaof' (Redis 5+)
+        redis_conf_set "replicaof" "$REDIS_MASTER_HOST $REDIS_MASTER_PORT_NUMBER"
+    fi
+}
+
+########################
+# Disable Redis command(s)
+# Globals:
+#   REDIS_BASE_DIR
+# Arguments:
+#   $1 - Array of commands to disable
+# Returns:
+#   None
+#########################
+redis_disable_unsafe_commands() {
+    # The current syntax gets a comma separated list of commands, we split them
+    # before passing to redis_disable_unsafe_commands
+    read -r -a disabledCommands <<< "$(tr ',' ' ' <<< "$REDIS_DISABLE_COMMANDS")"
+    debug "Disabling commands: ${disabledCommands[*]}"
+    for cmd in "${disabledCommands[@]}"; do
+        if grep -E -q "^\s*rename-command\s+$cmd\s+\"\"\s*$" "$REDIS_CONF_FILE"; then
+            debug "$cmd was already disabled"
+            continue
+        fi
+        echo "rename-command $cmd \"\"" >> "$REDIS_CONF_FILE"
+    done
+}
+
+########################
+# Redis configure perissions
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_configure_permissions() {
+  debug "Ensuring expected directories/files exist"
+  for dir in "${REDIS_BASE_DIR}" "${REDIS_DATA_DIR}" "${REDIS_BASE_DIR}/tmp" "${REDIS_LOG_DIR}"; do
+      ensure_dir_exists "$dir"
+      if am_i_root; then
+          chown "$REDIS_DAEMON_USER:$REDIS_DAEMON_GROUP" "$dir"
+      fi
+  done
+}
+
+########################
+# Redis specific configuration to override the default one
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_override_conf() {
+  if [[ ! -e "${REDIS_MOUNTED_CONF_DIR}/redis.conf" ]]; then
+      # Configure Replication mode
+      if [[ -n "$REDIS_REPLICATION_MODE" ]]; then
+          redis_configure_replication
+      fi
+  fi
+}
+
+########################
+# Ensure Redis is initialized
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_initialize() {
+  redis_configure_default
+  redis_override_conf
+}
+
+#########################
+# Append include directives to redis.conf
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_append_include_conf() {
+    if [[ -f "$REDIS_OVERRIDES_FILE" ]]; then
+        # Remove all include statements including commented ones
+        redis_conf_set include "$REDIS_OVERRIDES_FILE"
+        redis_conf_unset "include"
+        echo "include $REDIS_OVERRIDES_FILE" >> "${REDIS_BASE_DIR}/etc/redis.conf"
+    fi
+}
+
+########################
+# Configures Redis permissions and general parameters (also used in redis-cluster container)
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_configure_default() {
+    info "Initializing Redis"
+
+    # This fixes an issue where the trap would kill the entrypoint.sh, if a PID was left over from a previous run
+    # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
+    rm -f "$REDIS_BASE_DIR/tmp/redis.pid"
+
+    redis_configure_permissions
+
+    # User injected custom configuration
+    if [[ -e "${REDIS_MOUNTED_CONF_DIR}/redis.conf" ]]; then
+        if [[ -e "$REDIS_BASE_DIR/etc/redis-default.conf" ]]; then
+            rm "${REDIS_BASE_DIR}/etc/redis-default.conf"
+        fi
+        cp "${REDIS_MOUNTED_CONF_DIR}/redis.conf" "${REDIS_BASE_DIR}/etc/redis.conf"
+    else
+        info "Setting Redis config file"
+        if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+            # Allow remote connections without password
+            redis_conf_set protected-mode no
+        fi
+        is_boolean_yes "$REDIS_ALLOW_REMOTE_CONNECTIONS" && redis_conf_set bind "0.0.0.0 ::" # Allow remote connections
+        # Enable AOF https://redis.io/topics/persistence#append-only-file
+        # Leave default fsync (every second)
+        redis_conf_set appendonly "${REDIS_AOF_ENABLED}"
+
+        #The value stored in $i here is the number of seconds and times of save rules in redis rdb mode
+        if is_empty_value "$REDIS_RDB_POLICY"; then
+            if is_boolean_yes "$REDIS_RDB_POLICY_DISABLED"; then
+                redis_conf_set save ""
+            fi
+        else
+            for i in ${REDIS_RDB_POLICY}; do
+                redis_conf_set save "${i//#/ }"
+            done
+        fi
+
+        redis_conf_set port "$REDIS_PORT_NUMBER"
+        # TLS configuration
+        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+            if [[ "$REDIS_PORT_NUMBER" ==  "6379" ]] && [[ "$REDIS_TLS_PORT_NUMBER" ==  "6379" ]]; then
+                # If both ports are set to default values, enable TLS traffic only
+                redis_conf_set port 0
+                redis_conf_set tls-port "$REDIS_TLS_PORT_NUMBER"
+            else
+                # Different ports were specified
+                redis_conf_set tls-port "$REDIS_TLS_PORT_NUMBER"
+            fi
+            redis_conf_set tls-cert-file "$REDIS_TLS_CERT_FILE"
+            redis_conf_set tls-key-file "$REDIS_TLS_KEY_FILE"
+            # shellcheck disable=SC2015
+            is_empty_value "$REDIS_TLS_CA_FILE" && redis_conf_set tls-ca-cert-dir "$REDIS_TLS_CA_DIR" || redis_conf_set tls-ca-cert-file "$REDIS_TLS_CA_FILE"
+            ! is_empty_value "$REDIS_TLS_KEY_FILE_PASS" && redis_conf_set tls-key-file-pass "$REDIS_TLS_KEY_FILE_PASS"
+            [[ -n "$REDIS_TLS_DH_PARAMS_FILE" ]] && redis_conf_set tls-dh-params-file "$REDIS_TLS_DH_PARAMS_FILE"
+            redis_conf_set tls-auth-clients "$REDIS_TLS_AUTH_CLIENTS"
+        fi
+        # Multithreading configuration
+        ! is_empty_value "$REDIS_IO_THREADS_DO_READS" && redis_conf_set "io-threads-do-reads" "$REDIS_IO_THREADS_DO_READS"
+        ! is_empty_value "$REDIS_IO_THREADS" && redis_conf_set "io-threads" "$REDIS_IO_THREADS"
+
+        if [[ -n "$REDIS_PASSWORD" ]]; then
+            redis_conf_set requirepass "$REDIS_PASSWORD"
+        else
+            redis_conf_unset requirepass
+        fi
+        if [[ -n "$REDIS_DISABLE_COMMANDS" ]]; then
+            redis_disable_unsafe_commands
+        fi
+        if [[ -n "$REDIS_ACLFILE" ]]; then
+            redis_conf_set aclfile "$REDIS_ACLFILE"
+        fi
+        redis_append_include_conf
+    fi
+}

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Bitnami Redis Cluster library
+
+# shellcheck disable=SC1090,SC1091
+
+# Load Generic Libraries
+. /opt/bitnami/scripts/libfile.sh
+. /opt/bitnami/scripts/libfs.sh
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libnet.sh
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/libservice.sh
+. /opt/bitnami/scripts/libvalidations.sh
+. /opt/bitnami/scripts/libredis.sh
+
+# Functions
+
+########################
+# Validate settings in REDIS_* env vars.
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_cluster_validate() {
+    debug "Validating settings in REDIS_* env vars.."
+    local error_code=0
+
+    # Auxiliary functions
+    print_validation_error() {
+        error "$1"
+        error_code=1
+    }
+
+    empty_password_enabled_warn() {
+        warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
+    }
+    empty_password_error() {
+        print_validation_error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
+    }
+
+    if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+        empty_password_enabled_warn
+    else
+        [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
+    fi
+
+    if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+        [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
+    fi
+
+    [[ -z "$REDIS_NODES" ]] && print_validation_error "REDIS_NODES is required"
+
+    if [[ -z "$REDIS_PORT_NUMBER" ]]; then
+        print_validation_error "REDIS_PORT_NUMBER cannot be empty"
+    fi
+
+    if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
+        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas to the cluster creator"
+    fi
+
+    if ((REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP < 0)); then
+        print_validation_error "REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP must be greater or equal to zero"
+    fi
+
+    [[ "$error_code" -eq 0 ]] || exit "$error_code"
+}
+
+########################
+# Redis specific configuration to override the default one
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_cluster_override_conf() {
+    # Redis configuration to override
+    if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+        redis_conf_set cluster-announce-ip "$REDIS_CLUSTER_ANNOUNCE_IP"
+    fi
+    if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+        # Always set the announce-ip to avoid issues when using proxies and traffic restrictions.
+        redis_conf_set cluster-announce-ip "$(get_machine_ip)"
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_HOSTNAME"; then
+        redis_conf_set "cluster-announce-hostname" "$REDIS_CLUSTER_ANNOUNCE_HOSTNAME"
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_PREFERRED_ENDPOINT_TYPE"; then
+        redis_conf_set "cluster-preferred-endpoint-type" "$REDIS_CLUSTER_PREFERRED_ENDPOINT_TYPE"
+    fi
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        redis_conf_set tls-cluster yes
+        redis_conf_set tls-replication yes
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_PORT"; then
+        redis_conf_set "cluster-announce-port" "$REDIS_CLUSTER_ANNOUNCE_PORT"
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"; then
+        redis_conf_set "cluster-announce-bus-port" "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"
+    fi
+    # Multithreading configuration
+    if ! is_empty_value "$REDIS_IO_THREADS_DO_READS"; then
+        redis_conf_set "io-threads-do-reads" "$REDIS_IO_THREADS_DO_READS"
+    fi
+    if ! is_empty_value "$REDIS_IO_THREADS"; then
+        redis_conf_set "io-threads" "$REDIS_IO_THREADS"
+    fi
+}
+
+########################
+# Ensure Redis is initialized
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_cluster_initialize() {
+    redis_configure_default
+    redis_cluster_override_conf
+}
+
+########################
+# Creates the Redis cluster
+# Globals:
+#   REDIS_*
+# Arguments:
+#   - $@ Array with the hostnames
+# Returns:
+#   None
+#########################
+redis_cluster_create() {
+    local nodes=("$@")
+    local sockets=()
+    local wait_command
+    local create_command
+
+    for node in "${nodes[@]}"; do
+        read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+        wait_command="timeout 5 redis-cli -h ${host_and_port[0]} -p ${host_and_port[1]} ping"
+        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+            wait_command="${wait_command:0:-5} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} ping"
+        fi
+        while [[ $($wait_command) != 'PONG' ]]; do
+            echo "Node $node not ready, waiting for all the nodes to be ready..."
+            sleep 1
+        done
+    done
+
+    echo "Waiting ${REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP}s before querying node ip addresses"
+    sleep "${REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP}"
+
+    for node in "${nodes[@]}"; do
+        read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+        sockets+=("$(wait_for_dns_lookup "${host_and_port[0]}" "${REDIS_CLUSTER_DNS_LOOKUP_RETRIES}" "${REDIS_CLUSTER_DNS_LOOKUP_SLEEP}"):${host_and_port[1]}")
+    done
+
+    create_command="redis-cli --cluster create ${sockets[*]} --cluster-replicas ${REDIS_CLUSTER_REPLICAS} --cluster-yes"
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        create_command="${create_command} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE}"
+    fi
+    yes yes | $create_command || true
+    if redis_cluster_check "${sockets[0]}"; then
+        echo "Cluster correctly created"
+    else
+        echo "The cluster was already created, the nodes should have recovered it"
+    fi
+}
+
+#########################
+## Checks if the cluster state is correct.
+## Params:
+##  - $1: node where to check the cluster state
+#########################
+redis_cluster_check() {
+    if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        local -r check=$(redis-cli --tls --cert "${REDIS_TLS_CERT_FILE}" --key "${REDIS_TLS_KEY_FILE}" --cacert "${REDIS_TLS_CA_FILE}" --cluster check "$1")
+    else
+        local -r check=$(redis-cli --cluster check "$1")
+    fi
+    if [[ $check =~ "All 16384 slots covered" ]]; then
+        true
+    else
+        false
+    fi
+}
+
+#########################
+## Recovers the cluster when using dynamic IPs by changing them in the nodes.conf
+# Globals:
+#   REDIS_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redis_cluster_update_ips() {
+    read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
+    declare -A host_2_ip_array # Array to map hosts and IPs
+    # Update the IPs when a number of nodes > quorum change their IPs
+    if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" || ! -f "${REDIS_DATA_DIR}/nodes.conf" ]]; then
+        # It is the first initialization so store the nodes
+        for node in "${nodes[@]}"; do
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            ip=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
+            host_2_ip_array["$node"]="$ip"
+        done
+        echo "Storing map with hostnames and IPs"
+        declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
+    else
+        # The cluster was already started
+        . "${REDIS_DATA_DIR}/nodes.sh"
+        # Update the IPs in the nodes.conf
+        for node in "${nodes[@]}"; do
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            newIP=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
+            # The node can be new if we are updating the cluster, so catch the unbound variable error
+            if [[ ${host_2_ip_array[$node]+true} ]]; then
+                info "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP<NEWIP>:/g" "${REDIS_DATA_DIR}/nodes.conf")
+                echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
+            fi
+            host_2_ip_array["$node"]="$newIP"
+        done
+        replace_in_file "${REDIS_DATA_DIR}/nodes.conf" "<NEWIP>:" ":" false
+        declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
+    fi
+}
+
+#########################
+## Assigns a port to the host if one is not set using redis defaults
+# Globals:
+#   REDIS_*
+# Arguments:
+#   $1 - redis host or redis host and port
+# Returns:
+#   - 2 element Array of host and port
+#########################
+to_host_and_port() {
+    local host="${1:?host is required}"
+    read -r -a host_and_port <<< "$(echo "$host" | tr ":" " ")"
+
+    if [ "${#host_and_port[*]}" -eq "1" ]; then
+        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+            host_and_port=("${host_and_port[0]}" "${REDIS_TLS_PORT_NUMBER}")
+        else
+            host_and_port=("${host_and_port[0]}" "${REDIS_PORT_NUMBER}")
+        fi
+    fi
+
+    echo "${host_and_port[*]}"
+}

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster-env.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster-env.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+#
+# Environment configuration for redis-cluster
+
+# The values for all environment variables will be set in the below order of precedence
+# 1. Custom environment variables defined below after Bitnami defaults
+# 2. Constants defined in this file (environment variables with no default), i.e. BITNAMI_ROOT_DIR
+# 3. Environment variables overridden via external files using *_FILE variables (see below)
+# 4. Environment variables set externally (i.e. current Bash context/Dockerfile/userdata)
+
+# Load logging library
+# shellcheck disable=SC1090,SC1091
+. /opt/bitnami/scripts/liblog.sh
+
+export BITNAMI_ROOT_DIR="/opt/bitnami"
+export BITNAMI_VOLUME_DIR="/bitnami"
+
+# Logging configuration
+export MODULE="${MODULE:-redis-cluster}"
+export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
+
+# By setting an environment variable matching *_FILE to a file path, the prefixed environment
+# variable will be overridden with the value specified in that file
+redis_cluster_env_vars=(
+    REDIS_DATA_DIR
+    REDIS_OVERRIDES_FILE
+    REDIS_DISABLE_COMMANDS
+    REDIS_DATABASE
+    REDIS_AOF_ENABLED
+    REDIS_RDB_POLICY
+    REDIS_RDB_POLICY_DISABLED
+    REDIS_MASTER_HOST
+    REDIS_MASTER_PORT_NUMBER
+    REDIS_PORT_NUMBER
+    REDIS_ALLOW_REMOTE_CONNECTIONS
+    REDIS_REPLICATION_MODE
+    REDIS_REPLICA_IP
+    REDIS_REPLICA_PORT
+    REDIS_EXTRA_FLAGS
+    ALLOW_EMPTY_PASSWORD
+    REDIS_PASSWORD
+    REDIS_MASTER_PASSWORD
+    REDIS_ACLFILE
+    REDIS_IO_THREADS_DO_READS
+    REDIS_IO_THREADS
+    REDIS_TLS_ENABLED
+    REDIS_TLS_PORT_NUMBER
+    REDIS_TLS_CERT_FILE
+    REDIS_TLS_CA_DIR
+    REDIS_TLS_KEY_FILE
+    REDIS_TLS_KEY_FILE_PASS
+    REDIS_TLS_CA_FILE
+    REDIS_TLS_DH_PARAMS_FILE
+    REDIS_TLS_AUTH_CLIENTS
+    REDIS_CLUSTER_CREATOR
+    REDIS_CLUSTER_REPLICAS
+    REDIS_CLUSTER_DYNAMIC_IPS
+    REDIS_CLUSTER_ANNOUNCE_IP
+    REDIS_CLUSTER_ANNOUNCE_PORT
+    REDIS_CLUSTER_ANNOUNCE_BUS_PORT
+    REDIS_DNS_RETRIES
+    REDIS_NODES
+    REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP
+    REDIS_CLUSTER_DNS_LOOKUP_RETRIES
+    REDIS_CLUSTER_DNS_LOOKUP_SLEEP
+    REDIS_CLUSTER_ANNOUNCE_HOSTNAME
+    REDIS_CLUSTER_PREFERRED_ENDPOINT_TYPE
+    REDIS_TLS_PORT
+)
+for env_var in "${redis_cluster_env_vars[@]}"; do
+    file_env_var="${env_var}_FILE"
+    if [[ -n "${!file_env_var:-}" ]]; then
+        if [[ -r "${!file_env_var:-}" ]]; then
+            export "${env_var}=$(< "${!file_env_var}")"
+            unset "${file_env_var}"
+        else
+            warn "Skipping export of '${env_var}'. '${!file_env_var:-}' is not readable."
+        fi
+    fi
+done
+unset redis_cluster_env_vars
+
+# Paths
+export REDIS_VOLUME_DIR="/bitnami/redis"
+export REDIS_BASE_DIR="${BITNAMI_ROOT_DIR}/redis"
+export REDIS_CONF_DIR="${REDIS_BASE_DIR}/etc"
+export REDIS_DEFAULT_CONF_DIR="${REDIS_BASE_DIR}/etc.default"
+export REDIS_DATA_DIR="${REDIS_DATA_DIR:-${REDIS_VOLUME_DIR}/data}"
+export REDIS_MOUNTED_CONF_DIR="${REDIS_BASE_DIR}/mounted-etc"
+export REDIS_OVERRIDES_FILE="${REDIS_OVERRIDES_FILE:-${REDIS_MOUNTED_CONF_DIR}/overrides.conf}"
+export REDIS_CONF_FILE="${REDIS_CONF_DIR}/redis.conf"
+export REDIS_LOG_DIR="${REDIS_BASE_DIR}/logs"
+export REDIS_LOG_FILE="${REDIS_LOG_DIR}/redis.log"
+export REDIS_TMP_DIR="${REDIS_BASE_DIR}/tmp"
+export REDIS_PID_FILE="${REDIS_TMP_DIR}/redis.pid"
+export REDIS_BIN_DIR="${REDIS_BASE_DIR}/bin"
+export PATH="${REDIS_BIN_DIR}:${BITNAMI_ROOT_DIR}/common/bin:${PATH}"
+
+# System users (when running with a privileged user)
+export REDIS_DAEMON_USER="redis"
+export REDIS_DAEMON_GROUP="redis"
+
+# Redis settings
+export REDIS_DISABLE_COMMANDS="${REDIS_DISABLE_COMMANDS:-}"
+export REDIS_DATABASE="${REDIS_DATABASE:-redis}"
+export REDIS_AOF_ENABLED="${REDIS_AOF_ENABLED:-yes}"
+export REDIS_RDB_POLICY="${REDIS_RDB_POLICY:-}"
+export REDIS_RDB_POLICY_DISABLED="${REDIS_RDB_POLICY_DISABLED:-no}"
+export REDIS_MASTER_HOST="${REDIS_MASTER_HOST:-}"
+export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
+export REDIS_DEFAULT_PORT_NUMBER="6379" # only used at build time
+export REDIS_PORT_NUMBER="${REDIS_PORT_NUMBER:-$REDIS_DEFAULT_PORT_NUMBER}"
+export REDIS_ALLOW_REMOTE_CONNECTIONS="${REDIS_ALLOW_REMOTE_CONNECTIONS:-yes}"
+export REDIS_REPLICATION_MODE="${REDIS_REPLICATION_MODE:-}"
+export REDIS_REPLICA_IP="${REDIS_REPLICA_IP:-}"
+export REDIS_REPLICA_PORT="${REDIS_REPLICA_PORT:-}"
+export REDIS_EXTRA_FLAGS="${REDIS_EXTRA_FLAGS:-}"
+export ALLOW_EMPTY_PASSWORD="${ALLOW_EMPTY_PASSWORD:-no}"
+export REDIS_PASSWORD="${REDIS_PASSWORD:-}"
+export REDIS_MASTER_PASSWORD="${REDIS_MASTER_PASSWORD:-}"
+export REDIS_ACLFILE="${REDIS_ACLFILE:-}"
+export REDIS_IO_THREADS_DO_READS="${REDIS_IO_THREADS_DO_READS:-}"
+export REDIS_IO_THREADS="${REDIS_IO_THREADS:-}"
+
+# TLS settings
+export REDIS_TLS_ENABLED="${REDIS_TLS_ENABLED:-no}"
+REDIS_TLS_PORT_NUMBER="${REDIS_TLS_PORT_NUMBER:-"${REDIS_TLS_PORT:-}"}"
+export REDIS_TLS_PORT_NUMBER="${REDIS_TLS_PORT_NUMBER:-6379}"
+export REDIS_TLS_CERT_FILE="${REDIS_TLS_CERT_FILE:-}"
+export REDIS_TLS_CA_DIR="${REDIS_TLS_CA_DIR:-}"
+export REDIS_TLS_KEY_FILE="${REDIS_TLS_KEY_FILE:-}"
+export REDIS_TLS_KEY_FILE_PASS="${REDIS_TLS_KEY_FILE_PASS:-}"
+export REDIS_TLS_CA_FILE="${REDIS_TLS_CA_FILE:-}"
+export REDIS_TLS_DH_PARAMS_FILE="${REDIS_TLS_DH_PARAMS_FILE:-}"
+export REDIS_TLS_AUTH_CLIENTS="${REDIS_TLS_AUTH_CLIENTS:-yes}"
+
+# Redis Cluster settings
+export REDIS_CLUSTER_CREATOR="${REDIS_CLUSTER_CREATOR:-no}"
+export REDIS_CLUSTER_REPLICAS="${REDIS_CLUSTER_REPLICAS:-1}"
+export REDIS_CLUSTER_DYNAMIC_IPS="${REDIS_CLUSTER_DYNAMIC_IPS:-yes}"
+export REDIS_CLUSTER_ANNOUNCE_IP="${REDIS_CLUSTER_ANNOUNCE_IP:-}"
+export REDIS_CLUSTER_ANNOUNCE_PORT="${REDIS_CLUSTER_ANNOUNCE_PORT:-}"
+export REDIS_CLUSTER_ANNOUNCE_BUS_PORT="${REDIS_CLUSTER_ANNOUNCE_BUS_PORT:-}"
+export REDIS_DNS_RETRIES="${REDIS_DNS_RETRIES:-120}"
+export REDIS_NODES="${REDIS_NODES:-}"
+export REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP="${REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP:-0}"
+export REDIS_CLUSTER_DNS_LOOKUP_RETRIES="${REDIS_CLUSTER_DNS_LOOKUP_RETRIES:-1}"
+export REDIS_CLUSTER_DNS_LOOKUP_SLEEP="${REDIS_CLUSTER_DNS_LOOKUP_SLEEP:-1}"
+export REDIS_CLUSTER_ANNOUNCE_HOSTNAME="${REDIS_CLUSTER_ANNOUNCE_HOSTNAME:-}"
+export REDIS_CLUSTER_PREFERRED_ENDPOINT_TYPE="${REDIS_CLUSTER_PREFERRED_ENDPOINT_TYPE:-ip}"
+
+# Custom environment variables may be defined below

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/entrypoint.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purposes
+
+# Load Redis environment variables
+. /opt/bitnami/scripts/redis-cluster-env.sh
+
+# Load libraries
+. /opt/bitnami/scripts/libbitnami.sh
+. /opt/bitnami/scripts/librediscluster.sh
+
+print_welcome_page
+
+# We add the copy from default config in the entrypoint to not break users 
+# bypassing the setup.sh logic. If the file already exists do not overwrite (in
+# case someone mounts a configuration file in /opt/bitnami/redis/etc)
+debug "Copying files from $REDIS_DEFAULT_CONF_DIR to $REDIS_CONF_DIR"
+cp -nr "$REDIS_DEFAULT_CONF_DIR"/. "$REDIS_CONF_DIR"
+
+if [[ "$*" = *"/run.sh"* ]]; then
+    info "** Starting Redis setup **"
+    /opt/bitnami/scripts/redis-cluster/setup.sh
+    info "** Redis setup finished! **"
+fi
+
+echo ""
+exec "$@"

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/postunpack.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/postunpack.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purposes
+
+# Load Redis environment variables
+. /opt/bitnami/scripts/redis-cluster-env.sh
+
+# Load libraries
+. /opt/bitnami/scripts/librediscluster.sh
+. /opt/bitnami/scripts/libfs.sh
+
+for dir in "$REDIS_VOLUME_DIR" "$REDIS_DATA_DIR" "$REDIS_BASE_DIR" "$REDIS_CONF_DIR" "$REDIS_DEFAULT_CONF_DIR"; do
+    ensure_dir_exists "$dir"
+done
+
+cp "${REDIS_BASE_DIR}/etc/redis-default.conf" "$REDIS_CONF_FILE"
+
+info "Setting Redis config file..."
+redis_conf_set port "$REDIS_DEFAULT_PORT_NUMBER"
+redis_conf_set dir "$REDIS_DATA_DIR"
+redis_conf_set pidfile "$REDIS_PID_FILE"
+redis_conf_set daemonize no
+redis_conf_set cluster-enabled yes
+redis_conf_set cluster-config-file "${REDIS_DATA_DIR}/nodes.conf"
+
+chmod -R g+rwX  "$REDIS_BASE_DIR" /bitnami/redis
+
+redis_conf_set logfile "" # Log to stdout
+
+# Copy all initially generated configuration files to the default directory
+# (this is to avoid breaking when entrypoint is being overridden)
+cp -r "${REDIS_CONF_DIR}/"* "$REDIS_DEFAULT_CONF_DIR"

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purposes
+
+# Enable job control
+# ref https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
+set -m
+
+# Load Redis environment variables
+. /opt/bitnami/scripts/redis-cluster-env.sh
+
+# Load libraries
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/librediscluster.sh
+
+read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
+
+ARGS=("--port" "$REDIS_PORT_NUMBER")
+ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
+
+if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+    ARGS+=("--requirepass" "$REDIS_PASSWORD")
+    ARGS+=("--masterauth" "$REDIS_PASSWORD")
+else
+    ARGS+=("--protected-mode" "no")
+fi
+
+# Add flags specified via the 'REDIS_EXTRA_FLAGS' environment variable
+read -r -a extra_flags <<< "$REDIS_EXTRA_FLAGS"
+[[ "${#extra_flags[@]}" -gt 0 ]] && ARGS+=("${extra_flags[@]}")
+
+ARGS+=("$@")
+
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR" && ! [[ -f "${REDIS_DATA_DIR}/nodes.conf" ]]; then
+    # Start Redis in background
+    if am_i_root; then
+        run_as_user "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
+    else
+        redis-server "${ARGS[@]}" &
+    fi
+    # Create the cluster
+    redis_cluster_create "${nodes[@]}"
+    # Bring redis process to foreground
+    fg
+else
+    if am_i_root; then
+        exec_as_user "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
+    else
+        exec redis-server "${ARGS[@]}"
+    fi
+fi

--- a/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
+++ b/bitnami/redis-cluster/8.6/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purposes
+
+# Load Redis environment variables
+. /opt/bitnami/scripts/redis-cluster-env.sh
+
+# Load libraries
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/libfs.sh
+. /opt/bitnami/scripts/librediscluster.sh
+
+# Ensure Redis environment variables settings are valid
+redis_cluster_validate
+# Ensure Redis is stopped when this script ends
+trap "redis_stop" EXIT
+am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" --group "$REDIS_DAEMON_GROUP"
+
+# Ensure Redis is initialized
+redis_cluster_initialize
+
+if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+    redis_cluster_update_ips
+fi


### PR DESCRIPTION
## What
Restores the `bitnami/redis-cluster/8.6` Debian build context (Dockerfile + prebuildfs + rootfs, 8.6.3-debian-12-r3) that upstream Bitnami deleted, which our daily upstream-sync pulled into `main`.

## Why
Upstream commit `abfbafcc7e4` ("redis 8.8 is the new latest branch") removed the redis/redis-cluster Debian Dockerfiles as part of Bitnami's "latest-only" policy. Our container CI matrix builds `redis-cluster`, so `find … -name Dockerfile` returned empty and the job failed with `No Dockerfiles found for redis-cluster`.

## How

- `git checkout abfbafcc7e4~1 -- bitnami/redis-cluster/8.6` (last commit before the deletion)
- Added `SCT-RESTORED.md` documenting provenance and that this is a stopgap.

## Testing
- All 9 CI-matrix containers confirmed to have a Dockerfile + reachable build inputs (minideb:bookworm and stacksmith tarballs all return 200, 2026-06-01).
- redis-cluster 8.6.3 built locally end-to-end (LF/Linux, mimicking the CI runner).

## Risk / notes
- Low: restores a previously-shipped, known-good context; additive only.
- Future upstream syncs won't re-delete this path (upstream no longer modifies it).
- This is a **stopgap**. redis-cluster is the forcing function to migrate off Bitnami images — tracked in INF-139 (epic INP-493).
