### PR TITLE
Pause daily upstream-sync; require manual review (INF-139)

### DIFF
--- a/.github/workflows/sct-upstream-sync.yml
+++ b/.github/workflows/sct-upstream-sync.yml
@@ -1,9 +1,14 @@
 name: 'SCT Sync Upstream'
 
 on:
-  schedule:
-    # Run daily at 2 AM UTC
-    - cron: '0 2 * * *'
+  # Daily schedule paused (INF-139): Bitnami's "latest-only" policy prunes older
+  # versioned Dockerfiles upstream (e.g. redis-cluster), and an unattended daily
+  # sync silently merges those deletions into main and breaks our self-build CI.
+  # Run this manually (workflow_dispatch) and review the diff before merging,
+  # until we have migrated off Bitnami images. To re-enable, uncomment below.
+  # schedule:
+  #   # Run daily at 2 AM UTC
+  #   - cron: '0 2 * * *'
   workflow_dispatch:
     # Allow manual triggering
 


### PR DESCRIPTION
## What
Pauses the daily scheduled run of `sct-upstream-sync.yml` (comments out the cron trigger) and keeps `workflow_dispatch` for manual, reviewed syncs.

## Why
Bitnami's "latest-only" policy deletes older versioned Dockerfiles upstream. The unattended daily sync silently merged the redis-cluster deletion into `main` and broke our self-build CI (see INF-139 / the redis-cluster restore). Until we migrate off Bitnami images, upstream syncs should be deliberate and diff-reviewed rather than automatic.

## How
- Commented out the `schedule:` cron block; left `workflow_dispatch` intact.
- To re-enable later, uncomment the block.

## Risk / notes
- Low: no functional change to the sync logic; only its trigger.
- Side effect: the daily failures from the unrelated `clossing-issues.yml` / `stale.yml` merge conflict stop, since the job no longer runs unattended.
- Trade-off: the fork no longer auto-tracks upstream. That's intended — given Bitnami is deprecating, we want to pull upstream changes only on purpose.
