### PR TITLE
INF-152: drop redis-cluster + redis-exporter from CI matrix

### DIFF
--- a/.github/workflows/sct-ci-pipeline.yml
+++ b/.github/workflows/sct-ci-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        container: ["os-shell", "postgresql", "postgres-exporter", "redis-cluster", "redis-exporter", "minio", "minio-client", "minio-object-browser", "kubectl"]
+        container: ["os-shell", "postgresql", "postgres-exporter", "minio", "minio-client", "minio-object-browser", "kubectl"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## INF-152 — drop redis-cluster + redis-exporter from CI matrix

SCT migrated off the Bitnami `redis-cluster` chart to the upstream CloudPirates HA `redis` chart (INF-140), which uses the oliver006 exporter pulled directly from upstream. Neither the `redis-cluster` nor the bitnami `redis-exporter` container is mirrored to `ghcr.io/sct-software` any longer, so they're removed from the build matrix.

**Merge after** the btp-product-infra decommission apply is complete (so nothing is still pulling these images). Part of INF-152.
